### PR TITLE
[feature] Add query to retrieve latest updated articles

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4,3 +4,8 @@ parameters:
 			message: "#^Property App\\\\Common\\\\Infrastructure\\\\Persistence\\\\Doctrine\\\\DoctrineRepository\\<T of object\\>\\:\\:\\$entityName \\(class\\-string\\<T of object\\>\\) does not accept class\\-string\\<object\\>\\.$#"
 			count: 1
 			path: src/Common/Infrastructure/Persistence/Doctrine/DoctrineRepository.php
+
+		-
+			message: "#^Method App\\\\Feed\\\\Infrastructure\\\\Persistence\\\\Doctrine\\\\Article\\\\DoctrineArticleRepository\\:\\:findLatest\\(\\) should return array\\<int, App\\\\Feed\\\\Domain\\\\Article\\\\Article\\> but returns mixed\\.$#"
+			count: 1
+			path: src/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepository.php

--- a/src-dev/Feed/Factory/ArticleFactory.php
+++ b/src-dev/Feed/Factory/ArticleFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Dev\Feed\Factory;
+
+use App\Feed\Domain\Article\Article;
+use App\Feed\Domain\Article\ArticleId;
+use App\Feed\Domain\Article\Url\Url;
+use App\Feed\Domain\Source\Source;
+use DateTime;
+use Ramsey\Uuid\Uuid;
+
+final class ArticleFactory
+{
+    private ArticleId $id;
+    private string $title;
+    private string $summary;
+    private Url $url;
+    private DateTime $updated;
+    private Source $source;
+
+    public function __construct()
+    {
+        $faker = \Faker\Factory::create();
+
+        $this->id = new ArticleId(Uuid::uuid4());
+        $this->title = $faker->sentence();
+        $this->summary = $faker->paragraph();
+        $this->url = Url::createFromString($faker->url());
+        $this->updated = $faker->dateTime();
+        $this->source = (new SourceFactory())->create();
+    }
+
+    public function withUpdated(DateTime $updated): self
+    {
+        $this->updated = $updated;
+
+        return $this;
+    }
+
+    public function create(): Article
+    {
+        return new Article(
+            $this->id,
+            $this->title,
+            $this->summary,
+            $this->url,
+            $this->updated,
+            $this->source,
+        );
+    }
+}

--- a/src-dev/Feed/Repository/InMemoryArticleRepository.php
+++ b/src-dev/Feed/Repository/InMemoryArticleRepository.php
@@ -11,7 +11,7 @@ final class InMemoryArticleRepository implements ArticleRepository
     /**
      * @var array<string, Article>
      */
-    private array $entities;
+    private array $entities = [];
 
     public function save(Article ...$articles): void
     {
@@ -23,5 +23,14 @@ final class InMemoryArticleRepository implements ArticleRepository
     public function find(ArticleId $id): ?Article
     {
         return $this->entities[(string) $id] ?? null;
+    }
+
+    public function findLatest(int $numberOfArticles): array
+    {
+        $entities = $this->entities;
+
+        usort($entities, fn (Article $a, Article $b) => $a->getUpdated() > $b->getUpdated() ? -1 : 1);
+
+        return array_values(array_slice($entities, 0, $numberOfArticles));
     }
 }

--- a/src/Feed/Application/Query/Article/Handler/LatestUpdatedArticlesHandler.php
+++ b/src/Feed/Application/Query/Article/Handler/LatestUpdatedArticlesHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Feed\Application\Query\Article\Handler;
+
+use App\Feed\Application\Query\Article\LatestUpdatedArticlesQuery;
+use App\Feed\Domain\Article\Article;
+use App\Feed\Domain\Article\ArticleRepository;
+
+final readonly class LatestUpdatedArticlesHandler
+{
+    public function __construct(
+        private ArticleRepository $articleRepository
+    ) {
+    }
+
+    /**
+     * @return list<Article>
+     */
+    public function __invoke(LatestUpdatedArticlesQuery $query): array
+    {
+        return $this->articleRepository->findLatest($query->numberOfArticles);
+    }
+}

--- a/src/Feed/Application/Query/Article/LatestUpdatedArticlesQuery.php
+++ b/src/Feed/Application/Query/Article/LatestUpdatedArticlesQuery.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Feed\Application\Query\Article;
+
+final readonly class LatestUpdatedArticlesQuery
+{
+    public function __construct(public int $numberOfArticles)
+    {
+    }
+}

--- a/src/Feed/Domain/Article/ArticleRepository.php
+++ b/src/Feed/Domain/Article/ArticleRepository.php
@@ -7,4 +7,10 @@ interface ArticleRepository
     public function save(Article ...$articles): void;
 
     public function find(ArticleId $id): ?Article;
+
+    /**
+     * @param int $numberOfArticles
+     * @return list<Article>
+     */
+    public function findLatest(int $numberOfArticles): array;
 }

--- a/src/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepository.php
+++ b/src/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepository.php
@@ -6,6 +6,7 @@ use App\Common\Infrastructure\Persistence\Doctrine\DoctrineRepository;
 use App\Feed\Domain\Article\Article;
 use App\Feed\Domain\Article\ArticleId;
 use App\Feed\Domain\Article\ArticleRepository;
+use Doctrine\Common\Collections\Criteria;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -26,5 +27,19 @@ final readonly class DoctrineArticleRepository extends DoctrineRepository implem
     public function find(ArticleId $id): ?Article
     {
         return $this->findWithoutLocking($id);
+    }
+
+    /**
+     * @param int $numberOfArticles
+     * @return List<Article>
+     */
+    public function findLatest(int $numberOfArticles): array
+    {
+        return $this->createQueryBuilder('a')
+            ->orderBy('updated', Criteria::DESC)
+            ->setMaxResults($numberOfArticles)
+            ->getQuery()
+            ->getResult()
+        ;
     }
 }

--- a/tests/Unit/Feed/Application/Query/Article/Handler/LatestUpdatedArticlesHandlerTest.php
+++ b/tests/Unit/Feed/Application/Query/Article/Handler/LatestUpdatedArticlesHandlerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Unit\Feed\Application\Query\Article\Handler;
+
+use App\Feed\Application\Query\Article\Handler\LatestUpdatedArticlesHandler;
+use App\Feed\Application\Query\Article\LatestUpdatedArticlesQuery;
+use App\Feed\Domain\Article\ArticleRepository;
+use DateTime;
+use Dev\Feed\Factory\ArticleFactory;
+use Dev\Feed\Repository\InMemoryArticleRepository;
+use PHPUnit\Framework\TestCase;
+
+final class LatestUpdatedArticlesHandlerTest extends TestCase
+{
+    private LatestUpdatedArticlesHandler $handler;
+
+    private ArticleRepository $articleRepository;
+
+    public function setUp(): void
+    {
+        $this->articleRepository = new InMemoryArticleRepository();
+
+        $this->handler = new LatestUpdatedArticlesHandler($this->articleRepository);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_retrieve_last_n_articles(): void
+    {
+        // Arrange
+        $article1 = (new ArticleFactory())->withUpdated(new DateTime('2000-05-20 8:00'))->create();
+        $article2 = (new ArticleFactory())->withUpdated(new DateTime('1999-05-20 8:00'))->create();
+        $article3 = (new ArticleFactory())->withUpdated(new DateTime('2000-05-20 8:01'))->create();
+        $article4 = (new ArticleFactory())->withUpdated(new DateTime('1998-05-20 8:00'))->create();
+        $article5 = (new ArticleFactory())->withUpdated(new DateTime('2000-06-20 8:00'))->create();
+        $article6 = (new ArticleFactory())->withUpdated(new DateTime('2000-05-20 7:59'))->create();
+
+        $this->articleRepository->save($article1, $article2, $article3, $article4, $article5, $article6);
+
+        $query = new LatestUpdatedArticlesQuery(3);
+
+        // Act
+        $articles = $this->handler->__invoke($query);
+
+        // Assert
+        self::assertCount(3, $articles);
+
+        self::assertSame($articles[0], $article5);
+        self::assertSame($articles[1], $article3);
+        self::assertSame($articles[2], $article1);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_empty_array_when_there_are_no_articles(): void
+    {
+        // Arrange
+        $query = new LatestUpdatedArticlesQuery(10);
+
+        // Act
+        $articles = $this->handler->__invoke($query);
+
+        // Assert
+        self::assertCount(0, $articles);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_subset_if_asked_articles_expands_available(): void
+    {
+        // Arrange
+        $article1 = (new ArticleFactory())->withUpdated(new DateTime('2000-05-20 8:00'))->create();
+        $article2 = (new ArticleFactory())->withUpdated(new DateTime('1999-05-20 8:00'))->create();
+        $article3 = (new ArticleFactory())->withUpdated(new DateTime('2000-05-20 8:01'))->create();
+
+        $this->articleRepository->save($article1, $article2, $article3);
+
+        $query = new LatestUpdatedArticlesQuery(100);
+
+        // Act
+        $articles = $this->handler->__invoke($query);
+
+        // Assert
+        self::assertCount(3, $articles);
+
+        self::assertSame($articles[0], $article3);
+        self::assertSame($articles[1], $article1);
+        self::assertSame($articles[2], $article2);
+    }
+}


### PR DESCRIPTION
Beside command handlers the application layer now also sports query handlers. Difference being is that the command handlers change the state of an entity (write) while the query handlers only query them (read).

To separate the concerns command handlers should never return data, this is the responsibility of the query handler.