### PR TITLE
[feature] Introduce doctrine tests

### DIFF
--- a/src-dev/Feed/Factory/ArticleFactory.php
+++ b/src-dev/Feed/Factory/ArticleFactory.php
@@ -30,6 +30,13 @@ final class ArticleFactory
         $this->source = (new SourceFactory())->create();
     }
 
+    public function withSource(Source $source): self
+    {
+        $this->source = $source;
+
+        return $this;
+    }
+
     public function withUpdated(DateTime $updated): self
     {
         $this->updated = $updated;

--- a/src-dev/Testing/PHPUnit/DoctrineTestCase.php
+++ b/src-dev/Testing/PHPUnit/DoctrineTestCase.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Dev\Testing\PHPUnit;
+
+use App\Feed\Infrastructure\Persistence\Doctrine\Source\DoctrineSourceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use LogicException;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+abstract class DoctrineTestCase extends KernelTestCase
+{
+    private ?ManagerRegistry $doctrine = null;
+
+    protected function getDoctrine(): ManagerRegistry
+    {
+        if ($this->doctrine === null) {
+            throw new LogicException(
+                "Calling `getDoctrine` before calling `parent::setUp()` is not possible."
+            );
+        }
+
+        return $this->doctrine;
+    }
+
+    protected function getEntityManager(): EntityManagerInterface
+    {
+        if ($this->doctrine === null) {
+            throw new LogicException(
+                "Calling `getEntityManager` before calling `parent::setUp()` is not possible."
+            );
+        }
+
+        $entityManager = $this->doctrine->getManager();
+
+        self::assertInstanceOf(EntityManagerInterface::class, $entityManager);
+
+        return $entityManager;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $doctrine = $this->getContainer()->get('doctrine');
+
+        self::assertInstanceOf(ManagerRegistry::class, $doctrine);
+
+        $this->doctrine = $doctrine;
+
+        $this->getEntityManager()->getConnection()->setNestTransactionsWithSavepoints(true);
+        $this->getEntityManager()->getConnection()->setAutoCommit(false);
+        $this->getEntityManager()->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->getEntityManager()->rollback();
+
+        parent::tearDown();
+    }
+}

--- a/tests/Functional/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepositoryTest.php
+++ b/tests/Functional/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepositoryTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Functional\Feed\Infrastructure\Persistence\Doctrine\Article;
+
+use App\Feed\Infrastructure\Persistence\Doctrine\Article\DoctrineArticleRepository;
+use DateTime;
+use Dev\Feed\Factory\ArticleFactory;
+use Dev\Feed\Factory\SourceFactory;
+use Dev\Testing\PHPUnit\DoctrineTestCase;
+
+class DoctrineArticleRepositoryTest extends DoctrineTestCase
+{
+    private DoctrineArticleRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = new DoctrineArticleRepository($this->getDoctrine());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_the_latest_articles_in_a_sorted_manner(): void
+    {
+        // Arrange
+        $source = (new SourceFactory())->create();
+        $this->getDoctrine()->getManager()->persist($source);
+
+        $article1 = (new ArticleFactory())->withSource($source)->withUpdated(new DateTime('2021-03-10 00:10:00'))->create();
+        $article2 = (new ArticleFactory())->withSource($source)->withUpdated(new DateTime('2020-03-10 00:00:00'))->create();
+        $article3 = (new ArticleFactory())->withSource($source)->withUpdated(new DateTime('2021-03-10 00:00:00'))->create();
+        $article4 = (new ArticleFactory())->withSource($source)->withUpdated(new DateTime('2020-03-10 00:00:00'))->create();
+
+        $this->repository->save($article1, $article2, $article3, $article4);
+        $this->getDoctrine()->resetManager();
+
+        // Act
+        $articles = $this->repository->findLatest(2);
+
+        // Assert
+        self::assertCount(2, $articles);
+
+        self::assertEquals($article1->getId(), $articles[0]->getId());
+        self::assertEquals($article3->getId(), $articles[1]->getId());
+    }
+}


### PR DESCRIPTION
Functional tests that can be used to test, for example, doctrine implementations of the repositories.

These tests are doctrine aware and wrap each test case in a transaction. The transaction will be rolled back after each test case assuring a clean database for the next case.