### PR TITLE
[QoL] Add package prefix for src/ and src-dev/

### DIFF
--- a/.idea/feed.iml
+++ b/.idea/feed.iml
@@ -6,6 +6,8 @@
       <sourceFolder url="file://$MODULE_DIR$/skeleton/tests" isTestSource="true" packagePrefix="App\Tests\" />
       <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="App" />
+      <sourceFolder url="file://$MODULE_DIR$/src-dev" isTestSource="false" packagePrefix="Dev" />
       <excludeFolder url="file://$MODULE_DIR$/skeleton/vendor/psr/container" />
       <excludeFolder url="file://$MODULE_DIR$/skeleton/vendor/symfony/polyfill-mbstring" />
       <excludeFolder url="file://$MODULE_DIR$/skeleton/vendor/psr/log" />


### PR DESCRIPTION
Phpstorm was missing the conifugration required to autofill namespaces while creating a new class. Here we add them.