### PR TITLE
[Refactor] utilize events in feed to article flow

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -5,5 +5,9 @@ framework:
             command.bus:
                 default_middleware:
                     enabled: true
+            event.bus:
+                default_middleware:
+                    enabled: true
+                    allow_no_handlers: true
         transports:
         routing:

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,14 +6,14 @@ parameters:
 			path: src/Common/Infrastructure/Persistence/Doctrine/DoctrineRepository.php
 
 		-
-			message: "#^Method App\\\\Feed\\\\Infrastructure\\\\Persistence\\\\Doctrine\\\\Article\\\\DoctrineArticleRepository\\:\\:findLatest\\(\\) should return array\\<int, App\\\\Feed\\\\Domain\\\\Article\\\\Article\\> but returns mixed\\.$#"
+			message: "#^Method App\\\\Feed\\\\Infrastructure\\\\Persistence\\\\Doctrine\\\\Article\\\\DoctrineArticleRepository\\:\\:findByUrl\\(\\) should return App\\\\Feed\\\\Domain\\\\Article\\\\Article\\|null but returns mixed\\.$#"
 			count: 1
 			path: src/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepository.php
 
 		-
-			message: "#^Parameter \\#2 \\$configurator of method Symfony\\\\Component\\\\DependencyInjection\\\\ContainerBuilder\\:\\:registerAttributeForAutoconfiguration\\(\\) expects callable\\(Symfony\\\\Component\\\\DependencyInjection\\\\ChildDefinition, App\\\\Common\\\\Infrastructure\\\\Messenger\\\\CommandBus\\\\AsCommandHandler, Reflector\\)\\: void, Closure\\(Symfony\\\\Component\\\\DependencyInjection\\\\ChildDefinition, App\\\\Common\\\\Infrastructure\\\\Messenger\\\\CommandBus\\\\AsCommandHandler, ReflectionClass\\|ReflectionMethod\\)\\: void given\\.$#"
+			message: "#^Method App\\\\Feed\\\\Infrastructure\\\\Persistence\\\\Doctrine\\\\Article\\\\DoctrineArticleRepository\\:\\:findLatest\\(\\) should return array\\<int, App\\\\Feed\\\\Domain\\\\Article\\\\Article\\> but returns mixed\\.$#"
 			count: 1
-			path: src/Kernel.php
+			path: src/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepository.php
 
 		-
 			message: "#^Method App\\\\Feed\\\\Infrastructure\\\\Persistence\\\\Doctrine\\\\Source\\\\DoctrineSourceRepository\\:\\:findByNameOrThrow\\(\\) should return App\\\\Feed\\\\Domain\\\\Source\\\\Source but returns mixed\\.$#"
@@ -21,6 +21,11 @@ parameters:
 			path: src/Feed/Infrastructure/Persistence/Doctrine/Source/DoctrineSourceRepository.php
 
 		-
-			message: "#^Method App\\\\Feed\\\\Infrastructure\\\\Persistence\\\\Doctrine\\\\Article\\\\DoctrineArticleRepository\\:\\:findByUrl\\(\\) should return App\\\\Feed\\\\Domain\\\\Article\\\\Article\\|null but returns mixed\\.$#"
+			message: "#^Parameter \\#2 \\$configurator of method Symfony\\\\Component\\\\DependencyInjection\\\\ContainerBuilder\\:\\:registerAttributeForAutoconfiguration\\(\\) expects callable\\(Symfony\\\\Component\\\\DependencyInjection\\\\ChildDefinition, App\\\\Common\\\\Infrastructure\\\\Messenger\\\\CommandBus\\\\AsCommandHandler, Reflector\\)\\: void, Closure\\(Symfony\\\\Component\\\\DependencyInjection\\\\ChildDefinition, App\\\\Common\\\\Infrastructure\\\\Messenger\\\\CommandBus\\\\AsCommandHandler, ReflectionClass\\|ReflectionMethod\\)\\: void given\\.$#"
 			count: 1
-			path: src/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepository.php
+			path: src/Kernel.php
+
+		-
+			message: "#^Parameter \\#2 \\$configurator of method Symfony\\\\Component\\\\DependencyInjection\\\\ContainerBuilder\\:\\:registerAttributeForAutoconfiguration\\(\\) expects callable\\(Symfony\\\\Component\\\\DependencyInjection\\\\ChildDefinition, App\\\\Common\\\\Infrastructure\\\\Messenger\\\\EventBus\\\\AsEventSubscriber, Reflector\\)\\: void, Closure\\(Symfony\\\\Component\\\\DependencyInjection\\\\ChildDefinition, App\\\\Common\\\\Infrastructure\\\\Messenger\\\\EventBus\\\\AsEventSubscriber, ReflectionClass\\|ReflectionMethod\\)\\: void given\\.$#"
+			count: 1
+			path: src/Kernel.php

--- a/src-dev/Common/Infrastructure/Messenger/EventBus/RecordingEventBus.php
+++ b/src-dev/Common/Infrastructure/Messenger/EventBus/RecordingEventBus.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Dev\Common\Infrastructure\Messenger\EventBus;
+
+use App\Common\Infrastructure\Messenger\EventBus\EventBus;
+
+final class RecordingEventBus implements EventBus
+{
+    /**
+     * @var list<object>
+     */
+    private array $recordedEvents = [];
+
+    public function dispatch(object $event): void
+    {
+        $this->recordedEvents[] = $event;
+    }
+
+    public function shiftEvent(): object
+    {
+        return array_shift($this->recordedEvents) ?? throw new \LogicException('There are no recorded events (left).');
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->recordedEvents === [];
+    }
+}

--- a/src/Common/Infrastructure/Messenger/EventBus/AsEventSubscriber.php
+++ b/src/Common/Infrastructure/Messenger/EventBus/AsEventSubscriber.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Common\Infrastructure\Messenger\EventBus;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class AsEventSubscriber
+{
+}

--- a/src/Common/Infrastructure/Messenger/EventBus/EventBus.php
+++ b/src/Common/Infrastructure/Messenger/EventBus/EventBus.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Common\Infrastructure\Messenger\EventBus;
+
+interface EventBus
+{
+    public function dispatch(object $event): void;
+}

--- a/src/Common/Infrastructure/Messenger/EventBus/Symfony/SymfonyMessengerEventBus.php
+++ b/src/Common/Infrastructure/Messenger/EventBus/Symfony/SymfonyMessengerEventBus.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Common\Infrastructure\Messenger\EventBus\Symfony;
+
+use App\Common\Infrastructure\Messenger\EventBus\EventBus;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsAlias(EventBus::class)]
+class SymfonyMessengerEventBus implements EventBus
+{
+    public function __construct(private MessageBusInterface $eventBus)
+    {
+    }
+
+    public function dispatch(object $event): void
+    {
+        try {
+            $this->eventBus->dispatch($event);
+        } catch (HandlerFailedException $handlerFailedException) {
+            $exceptions = $handlerFailedException->getNestedExceptions();
+
+            $firstException = reset($exceptions);
+
+            throw $firstException !== false ? $firstException : $handlerFailedException;
+        }
+    }
+}

--- a/src/Feed/Application/Command/Article/Handler/UpsertArticleHandler.php
+++ b/src/Feed/Application/Command/Article/Handler/UpsertArticleHandler.php
@@ -3,7 +3,7 @@
 namespace App\Feed\Application\Command\Article\Handler;
 
 use App\Common\Infrastructure\Messenger\CommandBus\AsCommandHandler;
-use App\Feed\Application\Command\Article\UpdateOrCreateArticleCommand;
+use App\Feed\Application\Command\Article\UpsertArticleCommand;
 use App\Feed\Domain\Article\Article;
 use App\Feed\Domain\Article\ArticleId;
 use App\Feed\Domain\Article\ArticleRepository;
@@ -20,7 +20,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  * Updates the article if the url is found in the article repository, otherwise it creates a new article.
  */
 #[AsCommandHandler]
-final readonly class UpdateOrCreateArticleHandler
+final readonly class UpsertArticleHandler
 {
     public function __construct(
         private ArticleRepository $articleRepository,
@@ -33,7 +33,7 @@ final readonly class UpdateOrCreateArticleHandler
      * @throws MalformedUrlException
      * @throws SourceNotFoundException
      */
-    public function __invoke(UpdateOrCreateArticleCommand $command): void
+    public function __invoke(UpsertArticleCommand $command): void
     {
         $source = $this->sourceRepository->findByNameOrThrow($command->sourceName);
 

--- a/src/Feed/Application/Command/Article/UpsertArticleCommand.php
+++ b/src/Feed/Application/Command/Article/UpsertArticleCommand.php
@@ -2,14 +2,14 @@
 
 namespace App\Feed\Application\Command\Article;
 
-use App\Feed\Application\Command\Article\Handler\UpdateOrCreateArticleHandler;
+use App\Feed\Application\Command\Article\Handler\UpsertArticleHandler;
 use DateTime;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 
 /**
- * @see UpdateOrCreateArticleHandler
+ * @see UpsertArticleHandler
  */
-final readonly class UpdateOrCreateArticleCommand
+final readonly class UpsertArticleCommand
 {
     public function __construct(
         public string $title,

--- a/src/Feed/Application/Command/Feed/FetchFeedCommand.php
+++ b/src/Feed/Application/Command/Feed/FetchFeedCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Feed\Application\Command\Feed;
+
+use App\Feed\Application\Command\Feed\Handler\FetchFeedHandler;
+
+/**
+ * @see FetchFeedHandler
+ */
+final readonly class FetchFeedCommand
+{
+    /**
+     * @param string $source
+     */
+    public function __construct(
+        public string $source
+    ) {
+    }
+}

--- a/src/Feed/Application/Command/Feed/Handler/FetchFeedHandler.php
+++ b/src/Feed/Application/Command/Feed/Handler/FetchFeedHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Feed\Application\Command\Feed\Handler;
+
+use App\Common\Infrastructure\Messenger\CommandBus\AsCommandHandler;
+use App\Common\Infrastructure\Messenger\EventBus\EventBus;
+use App\Feed\Application\Command\Feed\FetchFeedCommand;
+use App\Feed\Application\Event\Feed\FeedItemWasFetchedEvent;
+use App\Feed\Application\Exception\Feed\FeedCouldNotBeProvidedException;
+use App\Feed\Application\Service\FeedProvider\FeedProvider;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+final readonly class FetchFeedHandler
+{
+    /**
+     * @param ServiceProviderInterface<FeedProvider> $feedProviders
+     */
+    public function __construct(
+        #[TaggedLocator(FeedProvider::class, defaultIndexMethod: 'getSource')]
+        private ServiceProviderInterface $feedProviders,
+        private EventBus $eventBus,
+    ) {
+    }
+
+    /**
+     * @throws FeedCouldNotBeProvidedException
+     */
+    #[AsCommandHandler]
+    public function __invoke(FetchFeedCommand $command): void
+    {
+        if ($this->feedProviders->has($command->source) === false) {
+            throw FeedCouldNotBeProvidedException::withNonExistingSource($command->source);
+        }
+
+        $feedProvider = $this->feedProviders->get($command->source);
+
+        foreach ($feedProvider->fetchFeedItems() as $feedItem) {
+            $this->eventBus->dispatch(
+                new FeedItemWasFetchedEvent($feedItem)
+            );
+        }
+    }
+}

--- a/src/Feed/Application/Event/Feed/FeedItemWasFetchedEvent.php
+++ b/src/Feed/Application/Event/Feed/FeedItemWasFetchedEvent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Feed\Application\Event\Feed;
+
+use App\Feed\Application\Service\FeedProvider\FeedItem;
+use DateTime;
+
+final readonly class FeedItemWasFetchedEvent
+{
+    public function __construct(
+        public FeedItem $feedItem,
+    ) {
+    }
+}

--- a/src/Feed/Application/Exception/Feed/FeedCouldNotBeProvidedException.php
+++ b/src/Feed/Application/Exception/Feed/FeedCouldNotBeProvidedException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Feed\Application\Exception\Feed;
+
+use Exception;
+
+final class FeedCouldNotBeProvidedException extends Exception
+{
+    public static function withNonExistingSource(string $source): self
+    {
+        return new self(sprintf('There is no feed provider coupled to the `%s` source', $source));
+    }
+}

--- a/src/Feed/Application/Listener/Article/UpsertArticleOnFeedItemFetchedListener.php
+++ b/src/Feed/Application/Listener/Article/UpsertArticleOnFeedItemFetchedListener.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Feed\Application\Listener\Article;
+
+use App\Common\Infrastructure\Messenger\CommandBus\CommandBus;
+use App\Common\Infrastructure\Messenger\EventBus\AsEventSubscriber;
+use App\Feed\Application\Command\Article\UpsertArticleCommand;
+use App\Feed\Application\Event\Feed\FeedItemWasFetchedEvent;
+
+final readonly class UpsertArticleOnFeedItemFetchedListener
+{
+    public function __construct(
+        private CommandBus $commandBus,
+    ) {
+    }
+
+    #[AsEventSubscriber]
+    public function onFeedItemWasFetchedEvent(FeedItemWasFetchedEvent $event): void
+    {
+        $feedItem = $event->feedItem;
+
+        $this->commandBus->handle(new UpsertArticleCommand(
+            $feedItem->title,
+            $feedItem->summary,
+            $feedItem->url,
+            $feedItem->updated,
+            $feedItem->source
+        ));
+    }
+}

--- a/src/Feed/Infrastructure/Console/FetchExternalFeedsCLICommand.php
+++ b/src/Feed/Infrastructure/Console/FetchExternalFeedsCLICommand.php
@@ -3,7 +3,7 @@
 namespace App\Feed\Infrastructure\Console;
 
 use App\Common\Infrastructure\Messenger\CommandBus\CommandBus;
-use App\Feed\Application\Command\Article\UpdateOrCreateArticleCommand;
+use App\Feed\Application\Command\Article\UpsertArticleCommand;
 use App\Feed\Application\Service\FeedProvider\FeedProvider;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -42,7 +42,7 @@ class FetchExternalFeedsCLICommand extends Command
         $this->logger->info('[feed:fetch] Start syncing external feeds with our datastore');
 
         foreach ($feedItems as $feedItem) {
-            $this->commandBus->handle(new UpdateOrCreateArticleCommand(
+            $this->commandBus->handle(new UpsertArticleCommand(
                 $feedItem->title,
                 $feedItem->summary,
                 $feedItem->url,

--- a/src/Feed/Infrastructure/Console/FetchExternalFeedsCLICommand.php
+++ b/src/Feed/Infrastructure/Console/FetchExternalFeedsCLICommand.php
@@ -4,6 +4,7 @@ namespace App\Feed\Infrastructure\Console;
 
 use App\Common\Infrastructure\Messenger\CommandBus\CommandBus;
 use App\Feed\Application\Command\Article\UpsertArticleCommand;
+use App\Feed\Application\Command\Feed\FetchFeedCommand;
 use App\Feed\Application\Service\FeedProvider\FeedProvider;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -36,18 +37,8 @@ class FetchExternalFeedsCLICommand extends Command
                 'source' => $feedProvider::getSource(),
             ]);
 
-            $feedItems = array_merge($feedItems, $feedProvider->fetchFeedItems());
-        }
-
-        $this->logger->info('[feed:fetch] Start syncing external feeds with our datastore');
-
-        foreach ($feedItems as $feedItem) {
-            $this->commandBus->handle(new UpsertArticleCommand(
-                $feedItem->title,
-                $feedItem->summary,
-                $feedItem->url,
-                $feedItem->updated,
-                $feedItem->source
+            $this->commandBus->handle(new FetchFeedCommand(
+                $feedProvider::getSource(),
             ));
         }
 

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use App\Common\Infrastructure\Messenger\CommandBus\AsCommandHandler;
+use App\Common\Infrastructure\Messenger\EventBus\AsEventSubscriber;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -26,6 +27,20 @@ class Kernel extends BaseKernel
             if ($reflector instanceof \ReflectionMethod) {
                 if (isset($tagAttributes['method'])) {
                     throw new LogicException(sprintf('AsCommandHandler attribute cannot declare a method on "%s::%s()".', $reflector->class, $reflector->name));
+                }
+                $tagAttributes['method'] = $reflector->getName();
+            }
+
+            $definition->addTag('messenger.message_handler', $tagAttributes);
+        });
+
+        $container->registerAttributeForAutoconfiguration(AsEventSubscriber::class, static function (ChildDefinition $definition, AsEventSubscriber $attribute, \ReflectionClass|\ReflectionMethod $reflector): void {
+            $tagAttributes = get_object_vars($attribute);
+            $tagAttributes['bus'] = 'event.bus';
+
+            if ($reflector instanceof \ReflectionMethod) {
+                if (isset($tagAttributes['method'])) {
+                    throw new LogicException(sprintf('AsEventSubscriber attribute cannot declare a method on "%s::%s()".', $reflector->class, $reflector->name));
                 }
                 $tagAttributes['method'] = $reflector->getName();
             }

--- a/tests/Unit/Feed/Application/Command/Article/Handler/UpsertArticleHandlerTest.php
+++ b/tests/Unit/Feed/Application/Command/Article/Handler/UpsertArticleHandlerTest.php
@@ -2,8 +2,8 @@
 
 namespace Unit\Feed\Application\Command\Article\Handler;
 
-use App\Feed\Application\Command\Article\UpdateOrCreateArticleCommand;
-use App\Feed\Application\Command\Article\Handler\UpdateOrCreateArticleHandler;
+use App\Feed\Application\Command\Article\UpsertArticleCommand;
+use App\Feed\Application\Command\Article\Handler\UpsertArticleHandler;
 use App\Feed\Domain\Article\ArticleId;
 use App\Feed\Domain\Article\Url\Exception\MalformedUrlException;
 use App\Feed\Domain\Article\Url\Exception\SchemeNotSupportedException;
@@ -19,9 +19,9 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Ramsey\Uuid\Uuid;
 
-final class UpdateOrCreateArticleHandlerTest extends TestCase
+final class UpsertArticleHandlerTest extends TestCase
 {
-    private UpdateOrCreateArticleHandler $handler;
+    private UpsertArticleHandler $handler;
     private InMemoryArticleRepository $articleRepository;
     private InMemorySourceRepository $sourceRepository;
 
@@ -33,7 +33,7 @@ final class UpdateOrCreateArticleHandlerTest extends TestCase
         $this->sourceRepository = new InMemorySourceRepository();
         $this->logger = new InMemoryLogger();
 
-        $this->handler = new UpdateOrCreateArticleHandler(
+        $this->handler = new UpsertArticleHandler(
             $this->articleRepository,
             $this->sourceRepository,
             $this->logger,
@@ -56,7 +56,7 @@ final class UpdateOrCreateArticleHandlerTest extends TestCase
         $url = 'https://example.com/bananas?tasty=yes&tracking=loads#banana-phone';
         $updated = new DateTime();
 
-        $command = new UpdateOrCreateArticleCommand(
+        $command = new UpsertArticleCommand(
             $title,
             $summary,
             $url,
@@ -95,7 +95,7 @@ final class UpdateOrCreateArticleHandlerTest extends TestCase
         $summary = 'This article is about bananas.';
         $updated = new DateTime('2022-10-5 00:00:00');
 
-        $command = new UpdateOrCreateArticleCommand(
+        $command = new UpsertArticleCommand(
             $title,
             $summary,
             (string) $existingArticle->getUrl(),
@@ -133,7 +133,7 @@ final class UpdateOrCreateArticleHandlerTest extends TestCase
         $summary = 'This article is about bananas.';
         $updated = new DateTime('1996-10-27 00:00:00');
 
-        $command = new UpdateOrCreateArticleCommand(
+        $command = new UpsertArticleCommand(
             $title,
             $summary,
             (string) $existingArticle->getUrl(),
@@ -166,7 +166,7 @@ final class UpdateOrCreateArticleHandlerTest extends TestCase
     public function it_should_throw_if_source_does_not_exist(): void
     {
         // Arrange
-        $command = new UpdateOrCreateArticleCommand(
+        $command = new UpsertArticleCommand(
             'Very interesting article',
             'This article is about bananas.',
             'https://example.com/bananas?tasty=yes&tracking=loads#banana-phone',
@@ -194,7 +194,7 @@ final class UpdateOrCreateArticleHandlerTest extends TestCase
 
         $malformedUrl = 'missing-scheme.com';
 
-        $command = new UpdateOrCreateArticleCommand(
+        $command = new UpsertArticleCommand(
             'Very interesting article',
             'This article is about bananas.',
             $malformedUrl,
@@ -220,7 +220,7 @@ final class UpdateOrCreateArticleHandlerTest extends TestCase
 
         $this->sourceRepository->save($source);
 
-        $command = new UpdateOrCreateArticleCommand(
+        $command = new UpsertArticleCommand(
             'Very interesting article',
             'This article is about bananas.',
             'ftp://example.com/ftp-is-an-unsupported-scheme',

--- a/tests/Unit/Feed/Application/Command/Feed/Handler/FetchFeedHandlerTest.php
+++ b/tests/Unit/Feed/Application/Command/Feed/Handler/FetchFeedHandlerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Unit\Feed\Application\Command\Feed\Handler;
+
+use App\Feed\Application\Command\Article\Handler\UpsertArticleHandler;
+use App\Feed\Application\Command\Feed\FetchFeedCommand;
+use App\Feed\Application\Command\Feed\Handler\FetchFeedHandler;
+use App\Feed\Application\Event\Feed\FeedItemWasFetchedEvent;
+use App\Feed\Application\Exception\Feed\FeedCouldNotBeProvidedException;
+use App\Feed\Application\Service\FeedProvider\FeedItem;
+use App\Feed\Application\Service\FeedProvider\FeedProvider;
+use Dev\Common\Infrastructure\Logger\InMemoryLogger;
+use Dev\Common\Infrastructure\Messenger\EventBus\RecordingEventBus;
+use Dev\Feed\Repository\InMemoryArticleRepository;
+use Dev\Feed\Repository\InMemorySourceRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Service\ServiceLocatorTrait;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+final class FetchFeedHandlerTest extends TestCase
+{
+    private FetchFeedHandler $handler;
+    private RecordingEventBus $eventBus;
+
+    public function setUp(): void
+    {
+        $feedProviderServiceLocator = new class ([
+            'dummy_feed_1' => new class implements FeedProvider {
+                public function __invoke(): self
+                {
+                    return $this;
+                }
+
+                public static function getSource(): string
+                {
+                    return 'dummy_feed_1';
+                }
+
+                public function fetchFeedItems(): array
+                {
+                    return [
+                        new FeedItem(
+                            'test title 1.1',
+                            'test summary 1.1',
+                            'https://example.com/test-title-1-1',
+                            new \DateTime('2022-03-03 00:00:00'),
+                            self::getSource(),
+                        ),
+                        new FeedItem(
+                            'test title 1.2',
+                            'test summary 1.2',
+                            'https://example.com/test-title-1-2',
+                            new \DateTime('2022-03-03 00:00:00'),
+                            self::getSource(),
+                        )
+                    ];
+                }
+            }
+        ]) implements
+            ServiceProviderInterface
+        {
+            use ServiceLocatorTrait;
+        };
+
+        $this->eventBus = new RecordingEventBus();
+
+        $this->handler = new FetchFeedHandler(
+            $feedProviderServiceLocator,
+            $this->eventBus,
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_retrieve_the_feed(): void
+    {
+        // Arrange
+        $command = new FetchFeedCommand('dummy_feed_1');
+
+        // Act
+        $this->handler->__invoke($command);
+
+        // Assert
+        $event = $this->eventBus->shiftEvent();
+
+        self::assertInstanceOf(FeedItemWasFetchedEvent::class, $event);
+
+        self::assertEquals('test title 1.1', $event->feedItem->title);
+        self::assertEquals('test summary 1.1', $event->feedItem->summary);
+        self::assertEquals('https://example.com/test-title-1-1', $event->feedItem->url);
+        self::assertEquals(new \DateTime('2022-03-03 00:00:00'), $event->feedItem->updated);
+        self::assertEquals('dummy_feed_1', $event->feedItem->source);
+
+        $event2 = $this->eventBus->shiftEvent();
+
+        self::assertInstanceOf(FeedItemWasFetchedEvent::class, $event2);
+
+        self::assertEquals('test title 1.2', $event2->feedItem->title);
+        self::assertEquals('test summary 1.2', $event2->feedItem->summary);
+        self::assertEquals('https://example.com/test-title-1-2', $event2->feedItem->url);
+        self::assertEquals(new \DateTime('2022-03-03 00:00:00'), $event2->feedItem->updated);
+        self::assertEquals('dummy_feed_1', $event2->feedItem->source);
+
+        self::assertTrue($this->eventBus->isEmpty());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_throw_if_feed_could_not_be_found(): void
+    {
+        // Assert
+        self::expectExceptionObject(FeedCouldNotBeProvidedException::withNonExistingSource('non-existing-source'));
+
+        // Arrange
+        $command = new FetchFeedCommand('non-existing-source');
+
+        // Act
+        $this->handler->__invoke($command);
+    }
+}

--- a/tests/Unit/Feed/Application/Listener/Article/UpsertArticleOnFeedItemFetchedListenerTest.php
+++ b/tests/Unit/Feed/Application/Listener/Article/UpsertArticleOnFeedItemFetchedListenerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Unit\Feed\Application\Listener\Article;
+
+use App\Feed\Application\Command\Article\UpsertArticleCommand;
+use App\Feed\Application\Event\Feed\FeedItemWasFetchedEvent;
+use App\Feed\Application\Listener\Article\UpsertArticleOnFeedItemFetchedListener;
+use App\Feed\Application\Service\FeedProvider\FeedItem;
+use Dev\Common\Infrastructure\Messenger\CommandBus\RecordingCommandBus;
+use PHPUnit\Framework\TestCase;
+
+final class UpsertArticleOnFeedItemFetchedListenerTest extends TestCase
+{
+    private UpsertArticleOnFeedItemFetchedListener $listener;
+    private RecordingCommandBus $commandBus;
+
+    protected function setUp(): void
+    {
+        $this->commandBus = new RecordingCommandBus();
+        $this->listener = new UpsertArticleOnFeedItemFetchedListener($this->commandBus);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_dispatch_an_upsert_article_command_on_event(): void
+    {
+        // Arrange
+        $feedItem = new FeedItem(
+            'test title 1.1',
+            'test summary 1.1',
+            'https://example.com/test-title-1-1',
+            new \DateTime('2022-03-03 00:00:00'),
+            'test-source',
+        );
+
+        $event = new FeedItemWasFetchedEvent($feedItem);
+
+        // Act
+        $this->listener->onFeedItemWasFetchedEvent($event);
+
+        // Assert
+        $command = $this->commandBus->shiftCommand();
+
+        self::assertInstanceOf(UpsertArticleCommand::class, $command);
+
+        self::assertEquals($command->title, $feedItem->title);
+        self::assertEquals($command->url, $feedItem->url);
+        self::assertEquals($command->updated, $feedItem->updated);
+        self::assertEquals($command->summary, $feedItem->summary);
+        self::assertEquals($command->sourceName, $feedItem->source);
+
+        self::assertTrue($this->commandBus->isEmpty());
+    }
+}

--- a/tests/Unit/Feed/Infrastructure/Console/FetchExternalFeedsCLICommandTest.php
+++ b/tests/Unit/Feed/Infrastructure/Console/FetchExternalFeedsCLICommandTest.php
@@ -3,6 +3,7 @@
 namespace Unit\Feed\Infrastructure\Console;
 
 use App\Feed\Application\Command\Article\UpsertArticleCommand;
+use App\Feed\Application\Command\Feed\FetchFeedCommand;
 use App\Feed\Application\Service\FeedProvider\FeedItem;
 use App\Feed\Application\Service\FeedProvider\FeedProvider;
 use App\Feed\Infrastructure\Console\FetchExternalFeedsCLICommand;
@@ -87,19 +88,11 @@ final class FetchExternalFeedsCLICommandTest extends TestCase
         $commandTester->execute([]);
 
         // Assert
-        self::assertEquals(new UpsertArticleCommand(
-            'test title 1.1',
-            'test summary 1.1',
-            'https://example.com/test-title-1-1',
-            new \DateTime('2022-03-03 00:00:00'),
+        self::assertEquals(new FetchFeedCommand(
             'dummy_feed_1'
         ), $this->commandBus->shiftCommand());
 
-        self::assertEquals(new UpsertArticleCommand(
-            'test title 2.1',
-            'test summary 2.1',
-            'https://example.com/test-title-2-1',
-            new \DateTime('2022-03-03 00:00:00'),
+        self::assertEquals(new FetchFeedCommand(
             'dummy_feed_2'
         ), $this->commandBus->shiftCommand());
 

--- a/tests/Unit/Feed/Infrastructure/Console/FetchExternalFeedsCLICommandTest.php
+++ b/tests/Unit/Feed/Infrastructure/Console/FetchExternalFeedsCLICommandTest.php
@@ -2,7 +2,7 @@
 
 namespace Unit\Feed\Infrastructure\Console;
 
-use App\Feed\Application\Command\Article\UpdateOrCreateArticleCommand;
+use App\Feed\Application\Command\Article\UpsertArticleCommand;
 use App\Feed\Application\Service\FeedProvider\FeedItem;
 use App\Feed\Application\Service\FeedProvider\FeedProvider;
 use App\Feed\Infrastructure\Console\FetchExternalFeedsCLICommand;
@@ -87,7 +87,7 @@ final class FetchExternalFeedsCLICommandTest extends TestCase
         $commandTester->execute([]);
 
         // Assert
-        self::assertEquals(new UpdateOrCreateArticleCommand(
+        self::assertEquals(new UpsertArticleCommand(
             'test title 1.1',
             'test summary 1.1',
             'https://example.com/test-title-1-1',
@@ -95,7 +95,7 @@ final class FetchExternalFeedsCLICommandTest extends TestCase
             'dummy_feed_1'
         ), $this->commandBus->shiftCommand());
 
-        self::assertEquals(new UpdateOrCreateArticleCommand(
+        self::assertEquals(new UpsertArticleCommand(
             'test title 2.1',
             'test summary 2.1',
             'https://example.com/test-title-2-1',


### PR DESCRIPTION
# Reason

The current situation is not really scalable nor are the concerns properly seperated. The CLI command defined in the infrastructure layer fetched the feed, this should not be its responsibility. After fetching the feed it calls the command x amount of times to create an article based on the fetched feed. This is all done in a single lifecycle on a single thread.   

# Refactor

This refactor addresses both the scalability problem and the separating of concerns. A new command is introduced with the sole responsibility of fetching a single feed. For each item in the fetched feed this command dispatches an event. A listener acts on these events and calls the UpsertArticleCommand.

Now both the fetching of feeds and the upserting of articles are done in smaller single idempotent commands. In the future these commands can run asynchronously, by putting them in a queue, to allow horizontal scaling.

![refactored-feed-to-article-flow](https://github.com/browncat-nl/feed/assets/9071507/9adde6cf-ade2-437e-af32-894ac4032a9e)