### PR TITLE
[Fix] Source should be unique for each `feedProvider`

### DIFF
--- a/migrations/Version20231231123959.php
+++ b/migrations/Version20231231123959.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20231231123959 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Delete 'php.watch' source
+        $this->addSql("DELETE FROM sources WHERE id='9930338f-d07c-4030-ade6-5ac19821e554'");
+
+        $this->addSql("INSERT INTO sources (id, name) VALUES ('a9ba164c-5a86-43d2-b024-f38e6a227a41', 'php.watch-news')");
+        $this->addSql("INSERT INTO sources (id, name) VALUES ('18929b96-79a4-44bf-8d97-f442851b7b44', 'php.watch-changes')");
+
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("INSERT INTO sources (id, name) VALUES ('9930338f-d07c-4030-ade6-5ac19821e554','php.watch')");
+
+        $this->addSql("DELETE FROM sources WHERE id='a9ba164c-5a86-43d2-b024-f38e6a227a41'");
+        $this->addSql("DELETE FROM sources WHERE id='18929b96-79a4-44bf-8d97-f442851b7b44'");
+    }
+}

--- a/src/Feed/Application/Service/FeedProvider/PhpWatchChangesFeedProvider.php
+++ b/src/Feed/Application/Service/FeedProvider/PhpWatchChangesFeedProvider.php
@@ -20,7 +20,7 @@ final class PhpWatchChangesFeedProvider implements FeedProvider
 
     public static function getSource(): string
     {
-        return 'php.watch';
+        return 'php.watch-changes';
     }
 
     public function fetchFeedItems(): array

--- a/src/Feed/Application/Service/FeedProvider/PhpWatchNewsFeedProvider.php
+++ b/src/Feed/Application/Service/FeedProvider/PhpWatchNewsFeedProvider.php
@@ -20,7 +20,7 @@ final class PhpWatchNewsFeedProvider implements FeedProvider
 
     public static function getSource(): string
     {
-        return 'php.watch';
+        return 'php.watch-news';
     }
 
     public function fetchFeedItems(): array

--- a/src/Feed/Infrastructure/Framework/CompilerPass/FeedProviderSourceShouldBeUniqueCompilerPass.php
+++ b/src/Feed/Infrastructure/Framework/CompilerPass/FeedProviderSourceShouldBeUniqueCompilerPass.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Feed\Infrastructure\Framework\CompilerPass;
+
+use App\Feed\Application\Service\FeedProvider\FeedProvider;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class FeedProviderSourceShouldBeUniqueCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $sources = [];
+
+        $services = $container->findTaggedServiceIds(FeedProvider::class);
+
+        foreach ($services as $service => $attributes) {
+            if (class_exists($service) === false) {
+                throw new \Exception(sprintf('Couldn\'t derive existing FQCN from service %s, the service is probably aliased', $service));
+            }
+
+            if (method_exists($service, 'getSource') === false) {
+                throw new \Exception('%s must implement static method `getSource`.');
+            }
+
+            $source = call_user_func([$service, 'getSource']);
+
+            if (in_array($source, $sources)) {
+                throw new \Exception(sprintf(
+                    'The \'source\' on a FeedProvider should be unique. Duplicate source found for %s.',
+                    $service,
+                ));
+            }
+
+            $sources[] = $source;
+        }
+    }
+}

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -4,6 +4,7 @@ namespace App;
 
 use App\Common\Infrastructure\Messenger\CommandBus\AsCommandHandler;
 use App\Common\Infrastructure\Messenger\EventBus\AsEventSubscriber;
+use App\Feed\Infrastructure\Framework\CompilerPass\FeedProviderSourceShouldBeUniqueCompilerPass;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -47,5 +48,8 @@ class Kernel extends BaseKernel
 
             $definition->addTag('messenger.message_handler', $tagAttributes);
         });
+
+        // @todo move to bundle
+        $container->addCompilerPass(new FeedProviderSourceShouldBeUniqueCompilerPass());
     }
 }

--- a/tests/Unit/Feed/Application/Service/FeedProvider/PhpWatchChangesFeedProviderTest.php
+++ b/tests/Unit/Feed/Application/Service/FeedProvider/PhpWatchChangesFeedProviderTest.php
@@ -103,19 +103,19 @@ XML;
         self::assertSame("Change type: Change    Target version: 8.4 ", $feedItems[0]->summary);
         self::assertSame("https://php.watch/versions/8.4/password_hash-bcrypt-cost-increase", $feedItems[0]->url);
         self::assertEquals(\DateTime::createFromFormat('Y-m-d H:i', '2023-10-17 10:44'), $feedItems[0]->updated);
-        self::assertSame('php.watch', $feedItems[0]->source);
+        self::assertSame('php.watch-changes', $feedItems[0]->source);
 
         self::assertSame("phpinfo: Show PHP Integer Size information", $feedItems[1]->title);
         self::assertSame("Change type: New Feature    Target version: 8.4 ", $feedItems[1]->summary);
         self::assertSame("https://php.watch/versions/8.4/phpinfo-int-size", $feedItems[1]->url);
         self::assertEquals(\DateTime::createFromFormat('Y-m-d H:i', '2023-09-23 10:44'), $feedItems[1]->updated);
-        self::assertSame('php.watch', $feedItems[1]->source);
+        self::assertSame('php.watch-changes', $feedItems[1]->source);
 
         self::assertSame("Class constant type declarations in some PHP extension classes", $feedItems[2]->title);
         self::assertSame("Change type: Change    Target version: 8.3 ", $feedItems[2]->summary);
         self::assertSame("https://php.watch/versions/8.3/ext-class-constant-type-declarations", $feedItems[2]->url);
         self::assertEquals(\DateTime::createFromFormat('Y-m-d H:i', '2023-08-22 10:44'), $feedItems[2]->updated);
-        self::assertSame('php.watch', $feedItems[2]->source);
+        self::assertSame('php.watch-changes', $feedItems[2]->source);
     }
 
     /**
@@ -124,7 +124,7 @@ XML;
     public function it_should_get_the_source_name(): void
     {
         // Assert
-        self::assertSame('php.watch', PhpWatchChangesFeedProvider::getSource());
+        self::assertSame('php.watch-changes', PhpWatchChangesFeedProvider::getSource());
     }
 
     /**

--- a/tests/Unit/Feed/Application/Service/FeedProvider/PhpWatchNewsFeedProviderTest.php
+++ b/tests/Unit/Feed/Application/Service/FeedProvider/PhpWatchNewsFeedProviderTest.php
@@ -83,13 +83,13 @@ XML;
         self::assertSame("The first release candidate (RC1) for PHP 8.3 is now released, along with Windows QA builds and Docker images.", $feedItems[0]->summary);
         self::assertSame("https://php.watch/news/2023/08/php83-rc1-released", $feedItems[0]->url);
         self::assertEquals(\DateTime::createFromFormat('Y-m-d H:i', '2023-08-31 10:44'), $feedItems[0]->updated);
-        self::assertSame('php.watch', $feedItems[0]->source);
+        self::assertSame('php.watch-news', $feedItems[0]->source);
 
         self::assertSame("PHP 8.3 Beta Released", $feedItems[1]->title);
         self::assertSame("The first beta release of the upcoming PHP 8.3 is released.", $feedItems[1]->summary);
         self::assertSame("https://php.watch/news/2023/07/php83-beta-released", $feedItems[1]->url);
         self::assertEquals(\DateTime::createFromFormat('Y-m-d H:i', '2023-07-24 10:44'), $feedItems[1]->updated);
-        self::assertSame('php.watch', $feedItems[1]->source);
+        self::assertSame('php.watch-news', $feedItems[1]->source);
     }
 
     /**
@@ -98,7 +98,7 @@ XML;
     public function it_should_get_the_source_name(): void
     {
         // Assert
-        self::assertSame('php.watch', PhpWatchChangesFeedProvider::getSource());
+        self::assertSame('php.watch-news', PhpWatchNewsFeedProvider::getSource());
     }
 
     /**


### PR DESCRIPTION
The tagged locator uses the source as an index to retrieve the corresponding feedprovider. If there is a source that points to multiple services the locator fetches the first one it encounters. This results in the second feed not being fetched.

AFAIK Symfony does not provide a locator that can fetch multiple services by index.

There are multiple solutions to this problem:

- We could have the php.watch feed provider fetch both feeds.
- We could keep both the providers and give them a unique source.

In this PR we decided on the latter. It introduces two new sources, php.watch-changes and php.watch-news.