### PR TITLE
Create read model for article

### DIFF
--- a/src/Common/Infrastructure/Client/Graphql/Scalar/DateTimeType.php
+++ b/src/Common/Infrastructure/Client/Graphql/Scalar/DateTimeType.php
@@ -3,13 +3,14 @@
 namespace App\Common\Infrastructure\Client\Graphql\Scalar;
 
 use DateTime;
+use DateTimeImmutable;
 use GraphQL\Language\AST\StringValueNode;
 use Overblog\GraphQLBundle\Annotation as GraphQL;
 
 #[GraphQL\Scalar(name: "DateTime")]
 final readonly class DateTimeType
 {
-    public static function serialize(DateTime $value): string
+    public static function serialize(DateTime|DateTimeImmutable $value): string
     {
         return $value->format('Y-m-d H:i:s');
     }

--- a/src/Feed/Application/Model/Article/ArticleReadModel.php
+++ b/src/Feed/Application/Model/Article/ArticleReadModel.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Feed\Application\Model\Article;
+
+use App\Feed\Application\Model\Source\SourceReadModel;
+use App\Feed\Domain\Article\Article;
+use DateTimeImmutable;
+
+final readonly class ArticleReadModel
+{
+    private function __construct(
+        public string $title,
+        public string $summary,
+        public string $url,
+        public SourceReadModel $source,
+        public DateTimeImmutable $updated,
+    ) {
+    }
+
+    public static function fromArticle(Article $article): self
+    {
+        return new self(
+            $article->getTitle(),
+            $article->getSummary(),
+            (string) $article->getUrl(),
+            SourceReadModel::fromSource($article->getSource()),
+            DateTimeImmutable::createFromMutable($article->getUpdated()),
+        );
+    }
+}

--- a/src/Feed/Application/Model/Source/SourceReadModel.php
+++ b/src/Feed/Application/Model/Source/SourceReadModel.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Feed\Application\Model\Source;
+
+use App\Feed\Domain\Source\Source;
+
+final readonly class SourceReadModel
+{
+    private function __construct(
+        public string $id,
+        public string $name,
+    ) {
+    }
+
+    public static function fromSource(Source $source): self
+    {
+        return new self(
+            $source->getId(),
+            $source->getName(),
+        );
+    }
+}

--- a/src/Feed/Application/Query/Article/Handler/LatestUpdatedArticlesHandler.php
+++ b/src/Feed/Application/Query/Article/Handler/LatestUpdatedArticlesHandler.php
@@ -2,6 +2,7 @@
 
 namespace App\Feed\Application\Query\Article\Handler;
 
+use App\Feed\Application\Model\Article\ArticleReadModel;
 use App\Feed\Application\Query\Article\LatestUpdatedArticlesQuery;
 use App\Feed\Domain\Article\Article;
 use App\Feed\Domain\Article\ArticleRepository;
@@ -14,10 +15,13 @@ final readonly class LatestUpdatedArticlesHandler
     }
 
     /**
-     * @return list<Article>
+     * @return list<ArticleReadModel>
      */
     public function __invoke(LatestUpdatedArticlesQuery $query): array
     {
-        return $this->articleRepository->findLatest($query->offset, $query->numberOfArticles);
+        return array_map(
+            ArticleReadModel::fromArticle(...),
+            $this->articleRepository->findLatest($query->offset, $query->numberOfArticles),
+        );
     }
 }

--- a/src/Feed/Infrastructure/Client/Graphql/Query/GetLatestArticlesQuery.php
+++ b/src/Feed/Infrastructure/Client/Graphql/Query/GetLatestArticlesQuery.php
@@ -38,7 +38,7 @@ class GetLatestArticlesQuery
             $articleTypes = [];
 
             foreach ($articles as $article) {
-                $articleTypes[] = ArticleType::createFromArticle($article);
+                $articleTypes[] = ArticleType::createFromArticleReadModel($article);
             }
 
             return $articleTypes;

--- a/src/Feed/Infrastructure/Client/Graphql/Type/Article/ArticleType.php
+++ b/src/Feed/Infrastructure/Client/Graphql/Type/Article/ArticleType.php
@@ -3,9 +3,9 @@
 namespace App\Feed\Infrastructure\Client\Graphql\Type\Article;
 
 use App\Common\Infrastructure\Client\Graphql\Scalar\DateTimeType;
-use App\Feed\Domain\Article\Article;
+use App\Feed\Application\Model\Article\ArticleReadModel;
 use App\Feed\Infrastructure\Client\Graphql\Type\Source\SourceType;
-use DateTime;
+use DateTimeImmutable;
 use Overblog\GraphQLBundle\Annotation as GraphQL;
 
 #[GraphQL\Type(name: 'Article')]
@@ -21,18 +21,18 @@ final class ArticleType
         #[GraphQL\Field]
         public SourceType $source,
         #[GraphQl\Field(type: "DateTime")]
-        public DateTime $updated,
+        public DateTimeImmutable $updated,
     ) {
     }
 
-    public static function createFromArticle(Article $article): self
+    public static function createFromArticleReadModel(ArticleReadModel $article): self
     {
         return new self(
-            $article->getTitle(),
-            $article->getSummary(),
-            (string) $article->getUrl(),
-            SourceType::createFromSource($article->getSource()),
-            $article->getUpdated(),
+            $article->title,
+            $article->summary,
+            $article->url,
+            SourceType::createFromSourceReadModel($article->source),
+            $article->updated,
         );
     }
 }

--- a/src/Feed/Infrastructure/Client/Graphql/Type/Source/SourceType.php
+++ b/src/Feed/Infrastructure/Client/Graphql/Type/Source/SourceType.php
@@ -2,6 +2,7 @@
 
 namespace App\Feed\Infrastructure\Client\Graphql\Type\Source;
 
+use App\Feed\Application\Model\Source\SourceReadModel;
 use App\Feed\Domain\Source\Source;
 use Overblog\GraphQLBundle\Annotation as GraphQL;
 
@@ -16,11 +17,11 @@ final readonly class SourceType
     ) {
     }
 
-    public static function createFromSource(Source $source): self
+    public static function createFromSourceReadModel(SourceReadModel $source): self
     {
         return new self(
-            $source->getId(),
-            $source->getName(),
+            $source->id,
+            $source->name,
         );
     }
 }

--- a/tests/Unit/Feed/Application/Query/Article/Handler/LatestUpdatedArticlesHandlerTest.php
+++ b/tests/Unit/Feed/Application/Query/Article/Handler/LatestUpdatedArticlesHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace Unit\Feed\Application\Query\Article\Handler;
 
+use App\Feed\Application\Model\Article\ArticleReadModel;
 use App\Feed\Application\Query\Article\Handler\LatestUpdatedArticlesHandler;
 use App\Feed\Application\Query\Article\LatestUpdatedArticlesQuery;
 use App\Feed\Domain\Article\ArticleRepository;
@@ -46,9 +47,9 @@ final class LatestUpdatedArticlesHandlerTest extends TestCase
         // Assert
         self::assertCount(3, $articles);
 
-        self::assertSame($articles[0], $article5);
-        self::assertSame($articles[1], $article3);
-        self::assertSame($articles[2], $article1);
+        self::assertEquals($articles[0], ArticleReadModel::fromArticle($article5));
+        self::assertEquals($articles[1], ArticleReadModel::fromArticle($article3));
+        self::assertEquals($articles[2], ArticleReadModel::fromArticle($article1));
     }
 
     /**
@@ -74,9 +75,9 @@ final class LatestUpdatedArticlesHandlerTest extends TestCase
         // Assert
         self::assertCount(3, $articles);
 
-        self::assertSame($articles[0], $article6);
-        self::assertSame($articles[1], $article2);
-        self::assertSame($articles[2], $article4);
+        self::assertEquals($articles[0], ArticleReadModel::fromArticle($article6));
+        self::assertEquals($articles[1], ArticleReadModel::fromArticle($article2));
+        self::assertEquals($articles[2], ArticleReadModel::fromArticle($article4));
     }
 
     /**
@@ -114,8 +115,8 @@ final class LatestUpdatedArticlesHandlerTest extends TestCase
         // Assert
         self::assertCount(3, $articles);
 
-        self::assertSame($articles[0], $article3);
-        self::assertSame($articles[1], $article1);
-        self::assertSame($articles[2], $article2);
+        self::assertEquals($articles[0], ArticleReadModel::fromArticle($article3));
+        self::assertEquals($articles[1], ArticleReadModel::fromArticle($article1));
+        self::assertEquals($articles[2], ArticleReadModel::fromArticle($article2));
     }
 }


### PR DESCRIPTION
We are leaking domain logic to the infrastructure layer by allowing a query to return the Article domain entity directly.

In this commit we introduce a read model that can be exposed by the query handler instead. This fixes the domain leaking into the infrastructure layer.