### PR TITLE
Cache articles on query level

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "nelmio/cors-bundle": "^2.3",
         "overblog/graphql-bundle": "^0.15.2",
         "ramsey/uuid": "^4.7",
+        "symfony/cache": "6.3.*",
         "symfony/console": "6.3.*",
         "symfony/dotenv": "6.3.*",
         "symfony/flex": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9818498d9343ef8c2216c1fb2185ca5d",
+    "content-hash": "f711cf3a71e0674ca7dd6d271a7c5de7",
     "packages": [
         {
             "name": "brick/math",
@@ -2274,16 +2274,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v6.3.0",
+            "version": "v6.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "357bf04b1380f71e40b2d6592dbf7f2a948ca6b1"
+                "reference": "6c1a3ea078c4d88ee892530945df63a87981b2da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/357bf04b1380f71e40b2d6592dbf7f2a948ca6b1",
-                "reference": "357bf04b1380f71e40b2d6592dbf7f2a948ca6b1",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/6c1a3ea078c4d88ee892530945df63a87981b2da",
+                "reference": "6c1a3ea078c4d88ee892530945df63a87981b2da",
                 "shasum": ""
             },
             "require": {
@@ -2350,7 +2350,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v6.3.0"
+                "source": "https://github.com/symfony/cache/tree/v6.3.5"
             },
             "funding": [
                 {
@@ -2366,7 +2366,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-10T09:21:01+00:00"
+            "time": "2023-09-26T15:48:55+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -7917,5 +7917,5 @@
         "ext-iconv": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -1,2 +1,8 @@
 framework:
     cache:
+        app: cache.adapter.filesystem
+
+when@test:
+    framework:
+        cache:
+            app: cache.adapter.array

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,7 +16,7 @@ parameters:
 			path: src/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepository.php
 
 		-
-			message: "#^Method App\\\\Feed\\\\Infrastructure\\\\Persistence\\\\Doctrine\\\\Article\\\\DoctrineArticleRepository\\:\\:findLatest\\(\\) should return array\\<int, App\\\\Feed\\\\Domain\\\\Article\\\\Article\\> but returns mixed\\.$#"
+			message: "#^Parameter \\#1 \\$id of class App\\\\Feed\\\\Domain\\\\Article\\\\ArticleId constructor expects string, mixed given\\.$#"
 			count: 1
 			path: src/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepository.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Method Dev\\\\Common\\\\Infrastructure\\\\Cache\\\\RecordingCache\\:\\:get\\(\\) has parameter \\$metadata with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src-dev/Common/Infrastructure/Cache/RecordingCache.php
+
+		-
 			message: "#^Property App\\\\Common\\\\Infrastructure\\\\Persistence\\\\Doctrine\\\\DoctrineRepository\\<T of object\\>\\:\\:\\$entityName \\(class\\-string\\<T of object\\>\\) does not accept class\\-string\\<object\\>\\.$#"
 			count: 1
 			path: src/Common/Infrastructure/Persistence/Doctrine/DoctrineRepository.php

--- a/src-dev/Common/Infrastructure/Cache/RecordingCache.php
+++ b/src-dev/Common/Infrastructure/Cache/RecordingCache.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Dev\Common\Infrastructure\Cache;
+
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+#[AsDecorator(ArrayAdapter::class)]
+class RecordingCache implements CacheInterface
+{
+    /**
+     * @var array<string, list<mixed>>
+     */
+    private array $cacheHits = [];
+
+    /**
+     * @var array<string, bool>
+     */
+    private array $deletes = [];
+
+    public function __construct(
+        #[AutowireDecorated]
+        private ArrayAdapter $inner,
+    ) {
+    }
+
+    public function get(string $key, callable $callback, float $beta = null, array &$metadata = null): mixed
+    {
+        $isHit = true;
+
+        $result =  $this->inner->get(
+            $key,
+            function (ItemInterface $item) use ($callback, &$isHit) {
+                // The callback is called, this means the item is not found in the cache. The cache is not hit.
+                $isHit = false;
+
+                return $callback($item, true);
+            },
+            $beta,
+            $metadata
+        );
+
+        if ($isHit) {
+            $this->cacheHits[$key][] = $result;
+        }
+
+        return $result;
+    }
+
+    public function delete(string $key): bool
+    {
+        $succeeded = $this->inner->delete($key);
+
+        $this->deletes[$key] = $succeeded;
+
+        return $succeeded;
+    }
+
+    public function cacheIsHitForKey(string $key): bool
+    {
+        return isset($this->cacheHits[$key]);
+    }
+
+    public function cacheIsDeletedForKey(string $key) : bool
+    {
+        return isset($this->deletes[$key]) && $this->deletes[$key];
+    }
+}

--- a/src-dev/Common/Infrastructure/Cache/RecordingCache.php
+++ b/src-dev/Common/Infrastructure/Cache/RecordingCache.php
@@ -64,7 +64,7 @@ class RecordingCache implements CacheInterface
         return isset($this->cacheHits[$key]);
     }
 
-    public function cacheIsDeletedForKey(string $key) : bool
+    public function cacheIsDeletedForKey(string $key): bool
     {
         return isset($this->deletes[$key]) && $this->deletes[$key];
     }

--- a/src-dev/Feed/Repository/InMemoryArticleRepository.php
+++ b/src-dev/Feed/Repository/InMemoryArticleRepository.php
@@ -38,13 +38,16 @@ final class InMemoryArticleRepository implements ArticleRepository
         return count($this->entities);
     }
 
-    public function findLatest(int $offset, int $numberOfArticles): array
+    public function findLatestIds(int $offset, int $numberOfArticles): array
     {
         $entities = $this->entities;
 
         usort($entities, fn (Article $a, Article $b) => $a->getUpdated() > $b->getUpdated() ? -1 : 1);
 
-        return array_values(array_slice($entities, $offset, $numberOfArticles));
+        return array_map(
+            fn(Article $entity) => $entity->getId(),
+            array_values(array_slice($entities, $offset, $numberOfArticles))
+        );
     }
 
     public function findByUrl(string $url): ?Article

--- a/src-dev/Feed/Repository/InMemoryArticleRepository.php
+++ b/src-dev/Feed/Repository/InMemoryArticleRepository.php
@@ -5,6 +5,7 @@ namespace Dev\Feed\Repository;
 use App\Feed\Domain\Article\Article;
 use App\Feed\Domain\Article\ArticleId;
 use App\Feed\Domain\Article\ArticleRepository;
+use App\Feed\Domain\Article\Exception\ArticleNotFoundException;
 use App\Feed\Domain\Article\Url\Url;
 
 final class InMemoryArticleRepository implements ArticleRepository
@@ -24,6 +25,12 @@ final class InMemoryArticleRepository implements ArticleRepository
     public function find(ArticleId $id): ?Article
     {
         return $this->entities[(string) $id] ?? null;
+    }
+
+
+    public function findOrThrow(ArticleId $id): Article
+    {
+        return $this->find($id) ?? throw ArticleNotFoundException::withArticleId($id);
     }
 
     public function count(): int

--- a/src/Feed/Application/Command/Article/Handler/UpsertArticleHandler.php
+++ b/src/Feed/Application/Command/Article/Handler/UpsertArticleHandler.php
@@ -3,7 +3,10 @@
 namespace App\Feed\Application\Command\Article\Handler;
 
 use App\Common\Infrastructure\Messenger\CommandBus\AsCommandHandler;
+use App\Common\Infrastructure\Messenger\EventBus\EventBus;
 use App\Feed\Application\Command\Article\UpsertArticleCommand;
+use App\Feed\Application\Event\Article\ArticleAddedEvent;
+use App\Feed\Application\Event\Article\ArticleUpdatedEvent;
 use App\Feed\Domain\Article\Article;
 use App\Feed\Domain\Article\ArticleId;
 use App\Feed\Domain\Article\ArticleRepository;
@@ -26,6 +29,7 @@ final readonly class UpsertArticleHandler
         private ArticleRepository $articleRepository,
         private SourceRepository $sourceRepository,
         private LoggerInterface $logger,
+        private EventBus $eventBus,
     ) {
     }
 
@@ -52,6 +56,9 @@ final readonly class UpsertArticleHandler
             );
 
             $this->articleRepository->save($article);
+
+            $this->eventBus->dispatch(new ArticleAddedEvent($article->getId()));
+
             return;
         }
 
@@ -77,5 +84,7 @@ final readonly class UpsertArticleHandler
         $existingArticle->setSource($source);
 
         $this->articleRepository->save($existingArticle);
+
+        $this->eventBus->dispatch(new ArticleUpdatedEvent($existingArticle->getId()));
     }
 }

--- a/src/Feed/Application/Event/Article/ArticleAddedEvent.php
+++ b/src/Feed/Application/Event/Article/ArticleAddedEvent.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Feed\Application\Event\Article;
+
+final readonly class ArticleAddedEvent
+{
+    public function __construct(
+        public string $articleId,
+    ) {
+    }
+}

--- a/src/Feed/Application/Event/Article/ArticleUpdatedEvent.php
+++ b/src/Feed/Application/Event/Article/ArticleUpdatedEvent.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Feed\Application\Event\Article;
+
+final readonly class ArticleUpdatedEvent
+{
+    public function __construct(
+        public string $articleId,
+    ) {
+    }
+}

--- a/src/Feed/Application/Listener/Article/InvalidateArticleCacheListener.php
+++ b/src/Feed/Application/Listener/Article/InvalidateArticleCacheListener.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Feed\Application\Listener\Article;
+
+use App\Common\Infrastructure\Messenger\EventBus\AsEventSubscriber;
+use App\Feed\Application\Event\Article\ArticleUpdatedEvent;
+use App\Feed\Infrastructure\Cache\FeedCacheKeys;
+use Symfony\Contracts\Cache\CacheInterface;
+
+final readonly class InvalidateArticleCacheListener
+{
+    public function __construct(
+        private CacheInterface $cache,
+    ) {
+    }
+
+    #[AsEventSubscriber]
+    public function onArticleUpdated(ArticleUpdatedEvent $event): void
+    {
+        $this->cache->delete(sprintf(FeedCacheKeys::ARTICLE_WITH_ARTICLE_ID->value, $event->articleId));
+    }
+}

--- a/src/Feed/Application/Listener/Article/InvalidateTotalArticlesCountCacheListener.php
+++ b/src/Feed/Application/Listener/Article/InvalidateTotalArticlesCountCacheListener.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Feed\Application\Listener\Article;
+
+use App\Common\Infrastructure\Messenger\EventBus\AsEventSubscriber;
+use App\Feed\Application\Event\Article\ArticleAddedEvent;
+use App\Feed\Domain\Article\ArticleRepository;
+use App\Feed\Infrastructure\Cache\FeedCacheKeys;
+use Symfony\Contracts\Cache\CacheInterface;
+
+final readonly class InvalidateTotalArticlesCountCacheListener
+{
+    public function __construct(
+        private CacheInterface $cache
+    ) {
+    }
+
+    #[AsEventSubscriber]
+    public function onArticleAdded(ArticleAddedEvent $event): void
+    {
+        $this->cache->delete(FeedCacheKeys::TOTAL_ARTICLES_COUNT->value);
+    }
+}

--- a/src/Feed/Application/Query/Article/Handler/CountArticlesHandler.php
+++ b/src/Feed/Application/Query/Article/Handler/CountArticlesHandler.php
@@ -4,16 +4,23 @@ namespace App\Feed\Application\Query\Article\Handler;
 
 use App\Feed\Application\Query\Article\CountArticlesQuery;
 use App\Feed\Domain\Article\ArticleRepository;
+use App\Feed\Infrastructure\Cache\FeedCacheKeys;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 
 final readonly class CountArticlesHandler
 {
     public function __construct(
-        private ArticleRepository $repository
+        private ArticleRepository $repository,
+        private CacheInterface $cache,
     ) {
     }
 
     public function __invoke(CountArticlesQuery $query): int
     {
-        return $this->repository->count();
+        return $this->cache->get(
+            FeedCacheKeys::TOTAL_ARTICLES_COUNT->value,
+            fn() => $this->repository->count(),
+        );
     }
 }

--- a/src/Feed/Application/Query/Article/Handler/LatestUpdatedArticlesHandler.php
+++ b/src/Feed/Application/Query/Article/Handler/LatestUpdatedArticlesHandler.php
@@ -6,11 +6,15 @@ use App\Feed\Application\Model\Article\ArticleReadModel;
 use App\Feed\Application\Query\Article\LatestUpdatedArticlesQuery;
 use App\Feed\Domain\Article\Article;
 use App\Feed\Domain\Article\ArticleRepository;
+use App\Feed\Infrastructure\Cache\FeedCacheKeys;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 
 final readonly class LatestUpdatedArticlesHandler
 {
     public function __construct(
-        private ArticleRepository $articleRepository
+        private ArticleRepository $articleRepository,
+        private CacheInterface $cache,
     ) {
     }
 
@@ -19,9 +23,19 @@ final readonly class LatestUpdatedArticlesHandler
      */
     public function __invoke(LatestUpdatedArticlesQuery $query): array
     {
-        return array_map(
-            ArticleReadModel::fromArticle(...),
-            $this->articleRepository->findLatest($query->offset, $query->numberOfArticles),
-        );
+        $articleIds = $this->articleRepository->findLatestIds($query->offset, $query->numberOfArticles);
+
+        $articles = [];
+
+        foreach ($articleIds as $articleId) {
+            $articles[] = $this->cache->get(
+                sprintf(FeedCacheKeys::ARTICLE_WITH_ARTICLE_ID->value, $articleId),
+                fn() => ArticleReadModel::fromArticle(
+                    $this->articleRepository->findOrThrow($articleId)
+                ),
+            );
+        }
+
+        return $articles;
     }
 }

--- a/src/Feed/Domain/Article/ArticleRepository.php
+++ b/src/Feed/Domain/Article/ArticleRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Feed\Domain\Article;
 
+use App\Feed\Domain\Article\Exception\ArticleNotFoundException;
 use App\Feed\Domain\Article\Url\Url;
 
 interface ArticleRepository
@@ -9,6 +10,11 @@ interface ArticleRepository
     public function save(Article ...$articles): void;
 
     public function find(ArticleId $id): ?Article;
+
+    /**
+     * @throws ArticleNotFoundException
+     */
+    public function findOrThrow(ArticleId $id): Article;
 
     public function count(): int;
 

--- a/src/Feed/Domain/Article/ArticleRepository.php
+++ b/src/Feed/Domain/Article/ArticleRepository.php
@@ -20,9 +20,9 @@ interface ArticleRepository
 
     /**
      * @param int $numberOfArticles
-     * @return list<Article>
+     * @return list<ArticleId>
      */
-    public function findLatest(
+    public function findLatestIds(
         int $offset,
         int $numberOfArticles,
     ): array;

--- a/src/Feed/Domain/Article/Exception/ArticleNotFoundException.php
+++ b/src/Feed/Domain/Article/Exception/ArticleNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Feed\Domain\Article\Exception;
+
+use App\Feed\Domain\Article\ArticleId;
+
+final class ArticleNotFoundException extends \Exception
+{
+    public static function withArticleId(ArticleId $articleId): self
+    {
+        return new self(sprintf('Article with id %s not found.', (string) $articleId));
+    }
+}

--- a/src/Feed/Infrastructure/Cache/FeedCacheKeys.php
+++ b/src/Feed/Infrastructure/Cache/FeedCacheKeys.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Feed\Infrastructure\Cache;
+
+enum FeedCacheKeys : string
+{
+    case TOTAL_ARTICLES_COUNT = 'total_articles_count';
+}

--- a/src/Feed/Infrastructure/Cache/FeedCacheKeys.php
+++ b/src/Feed/Infrastructure/Cache/FeedCacheKeys.php
@@ -5,4 +5,5 @@ namespace App\Feed\Infrastructure\Cache;
 enum FeedCacheKeys : string
 {
     case TOTAL_ARTICLES_COUNT = 'total_articles_count';
+    case ARTICLE_WITH_ARTICLE_ID = 'article_with_article_id_%s';
 }

--- a/src/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepository.php
+++ b/src/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepository.php
@@ -6,6 +6,7 @@ use App\Common\Infrastructure\Persistence\Doctrine\DoctrineRepository;
 use App\Feed\Domain\Article\Article;
 use App\Feed\Domain\Article\ArticleId;
 use App\Feed\Domain\Article\ArticleRepository;
+use App\Feed\Domain\Article\Exception\ArticleNotFoundException;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Persistence\ManagerRegistry;
 use Webmozart\Assert\Assert;
@@ -28,6 +29,11 @@ final readonly class DoctrineArticleRepository extends DoctrineRepository implem
     public function find(ArticleId $id): ?Article
     {
         return $this->findWithoutLocking($id);
+    }
+
+    public function findOrThrow(ArticleId $id): Article
+    {
+        return $this->find($id) ?? throw ArticleNotFoundException::withArticleId($id);
     }
 
     public function count(): int

--- a/src/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepository.php
+++ b/src/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepository.php
@@ -50,19 +50,22 @@ final readonly class DoctrineArticleRepository extends DoctrineRepository implem
 
     /**
      * @param int $numberOfArticles
-     * @return List<Article>
+     * @return List<ArticleId>
      */
-    public function findLatest(
+    public function findLatestIds(
         int $offset,
         int $numberOfArticles,
     ): array {
-        return $this->createQueryBuilder('a')
-            ->orderBy('a.updated', Criteria::DESC)
-            ->setFirstResult($offset)
-            ->setMaxResults($numberOfArticles)
-            ->getQuery()
-            ->getResult()
-        ;
+         return array_map(
+             fn($id) => new ArticleId($id),
+             $this->createQueryBuilder('a')
+                ->select('a.id')
+                ->orderBy('a.updated', Criteria::DESC)
+                ->setFirstResult($offset)
+                ->setMaxResults($numberOfArticles)
+                ->getQuery()
+                ->getSingleColumnResult()
+         );
     }
 
     public function findByUrl(string $url): ?Article

--- a/symfony.lock
+++ b/symfony.lock
@@ -64,6 +64,15 @@
             "config/routes/graphql.yaml"
         ]
     },
+    "phpstan/phpstan": {
+        "version": "1.10",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "5e490cc197fb6bb1ae22e5abbc531ddc633b6767"
+        }
+    },
     "phpunit/phpunit": {
         "version": "9.6",
         "recipe": {

--- a/tests/Functional/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepositoryTest.php
+++ b/tests/Functional/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepositoryTest.php
@@ -2,6 +2,8 @@
 
 namespace Functional\Feed\Infrastructure\Persistence\Doctrine\Article;
 
+use App\Feed\Domain\Article\ArticleId;
+use App\Feed\Domain\Article\Exception\ArticleNotFoundException;
 use App\Feed\Infrastructure\Persistence\Doctrine\Article\DoctrineArticleRepository;
 use DateTime;
 use Dev\Feed\Factory\ArticleFactory;
@@ -101,5 +103,17 @@ class DoctrineArticleRepositoryTest extends DoctrineTestCase
 
         // Assert
         self::assertSame(3, $count);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_throw_when_trying_to_find_a_non_existing_article_id(): void
+    {
+        // Assert
+        self::expectException(ArticleNotFoundException::class);
+
+        // Act
+        $this->repository->findOrThrow(new ArticleId('ddb01803-ef13-4195-bed1-3320a6b443ba'));
     }
 }

--- a/tests/Functional/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepositoryTest.php
+++ b/tests/Functional/Feed/Infrastructure/Persistence/Doctrine/Article/DoctrineArticleRepositoryTest.php
@@ -39,13 +39,13 @@ class DoctrineArticleRepositoryTest extends DoctrineTestCase
         $this->getDoctrine()->resetManager();
 
         // Act
-        $articles = $this->repository->findLatest(0, 2);
+        $articles = $this->repository->findLatestIds(0, 2);
 
         // Assert
         self::assertCount(2, $articles);
 
-        self::assertEquals($article1->getId(), $articles[0]->getId());
-        self::assertEquals($article3->getId(), $articles[1]->getId());
+        self::assertEquals($article1->getId(), $articles[0]);
+        self::assertEquals($article3->getId(), $articles[1]);
     }
 
     /**

--- a/tests/Unit/Feed/Application/Command/Article/Handler/UpsertArticleHandlerTest.php
+++ b/tests/Unit/Feed/Application/Command/Article/Handler/UpsertArticleHandlerTest.php
@@ -47,7 +47,6 @@ final class UpsertArticleHandlerTest extends TestCase
     {
         // Arrange
         $source = (new SourceFactory())->create();
-        $articleId = Uuid::uuid4();
 
         $this->sourceRepository->save($source);
 

--- a/tests/Unit/Feed/Application/Listener/Article/InvalidateArticleCacheListenerTest.php
+++ b/tests/Unit/Feed/Application/Listener/Article/InvalidateArticleCacheListenerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Unit\Feed\Application\Listener\Article;
+
+use App\Feed\Application\Event\Article\ArticleUpdatedEvent;
+use App\Feed\Application\Listener\Article\InvalidateArticleCacheListener;
+use App\Feed\Infrastructure\Cache\FeedCacheKeys;
+use Dev\Feed\Factory\ArticleFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+final class InvalidateArticleCacheListenerTest extends TestCase
+{
+    private InvalidateArticleCacheListener $listener;
+    private ArrayAdapter $cache;
+
+    protected function setUp(): void
+    {
+        $this->listener = new InvalidateArticleCacheListener(
+            $this->cache = new ArrayAdapter(),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_delete_the_cache_entry_when_the_article_is_updated(): void
+    {
+        // Arrange
+        $article = (new ArticleFactory())->create();
+        $cacheKey = sprintf(FeedCacheKeys::ARTICLE_WITH_ARTICLE_ID->value, $article->getId());
+
+        $this->cache->get(
+            $cacheKey,
+            fn (ItemInterface $item) => $article,
+        );
+
+        // Act
+        $this->listener->onArticleUpdated(new ArticleUpdatedEvent($article->getId()));
+
+        // Assert
+        self::assertFalse($this->cache->hasItem($cacheKey));
+    }
+}

--- a/tests/Unit/Feed/Application/Query/Article/Handler/CountArticlesHandlerTest.php
+++ b/tests/Unit/Feed/Application/Query/Article/Handler/CountArticlesHandlerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Unit\Feed\Application\Query\Article\Handler;
+
+use App\Feed\Application\Query\Article\CountArticlesQuery;
+use App\Feed\Application\Query\Article\Handler\CountArticlesHandler;
+use App\Feed\Infrastructure\Cache\FeedCacheKeys;
+use Dev\Common\Infrastructure\Cache\RecordingCache;
+use Dev\Feed\Factory\ArticleFactory;
+use Dev\Feed\Repository\InMemoryArticleRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\CacheItem;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+class CountArticlesHandlerTest extends TestCase
+{
+    private CountArticlesHandler $handler;
+
+    private InMemoryArticleRepository $repository;
+    private RecordingCache $cache;
+
+    protected function setUp(): void
+    {
+        $this->repository = new InMemoryArticleRepository();
+        $this->cache = new RecordingCache(new ArrayAdapter());
+
+        $this->handler = new CountArticlesHandler(
+            $this->repository,
+            $this->cache,
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_count_the_articles(): void
+    {
+        // Arrange
+        $this->repository->save(
+            (new ArticleFactory())->create(),
+            (new ArticleFactory())->create(),
+            (new ArticleFactory())->create(),
+        );
+
+        // Act
+        $count = $this->handler->__invoke(new CountArticlesQuery());
+
+        // Assert
+        self::assertSame(3, $count);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_get_the_count_from_the_cache(): void
+    {
+        // Arrange
+        $this->cache->get(FeedCacheKeys::TOTAL_ARTICLES_COUNT->value, fn (ItemInterface $item) => 109);
+
+        // Act
+        $count = $this->handler->__invoke(new CountArticlesQuery());
+
+        // Assert
+        self::assertTrue($this->cache->cacheIsHitForKey(FeedCacheKeys::TOTAL_ARTICLES_COUNT->value));
+
+        self::assertSame(109, $count);
+    }
+}


### PR DESCRIPTION
> ⚠️ Normally this would be split up in a bunch of isolated PRs but since nobody is reviewing this I didn't bother.

# Description

In this PR we add caching to the query layer. Reducing load on the database.

## Filling the cache
The cache is filled when a query handler can't find the key in the cache. When a process is filling the cache Symfony takes care of locking the key so it wouldn't cause a spike of cache fills.

## Cache lifetime
The cache may live as long as it can.

## Invalidating the cache
When an article is updated/added through a command an event is dispatched (che). A subscriber listens to this event and deletes the associated cache key.