### PR TITLE
Add feed url to Source

### DIFF
--- a/migrations/Version20241229101126.php
+++ b/migrations/Version20241229101126.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20241229101126 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the feed url to the source';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE sources ADD feed_url VARCHAR(512) NOT NULL DEFAULT ''");
+
+        $this->addSql("UPDATE sources SET feed_url='https://martinfowler.com/feed.atom' WHERE name='martinfowler.com'");
+        $this->addSql("UPDATE sources SET feed_url='https://php.watch/feed/php-changes.xml' WHERE name='php.watch-changes'");
+        $this->addSql("UPDATE sources SET feed_url='https://php.watch/feed/news.xml' WHERE name='php.watch-news'");
+        $this->addSql("UPDATE sources SET feed_url='https://stitcher.io/rss' WHERE name='stitcher.io'");
+        $this->addSql("UPDATE sources SET feed_url='https://feeds.feedburner.com/symfony/blog' WHERE name='symfony.com'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sources DROP feed_url');
+    }
+}

--- a/src-dev/Feed/Factory/ArticleFactory.php
+++ b/src-dev/Feed/Factory/ArticleFactory.php
@@ -2,9 +2,9 @@
 
 namespace Dev\Feed\Factory;
 
+use App\Common\Domain\Url\Url;
 use App\Feed\Domain\Article\Article;
 use App\Feed\Domain\Article\ArticleId;
-use App\Feed\Domain\Article\Url\Url;
 use App\Feed\Domain\Source\Source;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;

--- a/src-dev/Feed/Factory/SourceFactory.php
+++ b/src-dev/Feed/Factory/SourceFactory.php
@@ -2,6 +2,7 @@
 
 namespace Dev\Feed\Factory;
 
+use App\Common\Domain\Url\Url;
 use App\Feed\Domain\Source\Source;
 use App\Feed\Domain\Source\SourceId;
 use Ramsey\Uuid\Uuid;
@@ -10,6 +11,7 @@ class SourceFactory
 {
     private SourceId $id;
     private string $name;
+    private Url $url;
 
     public function __construct()
     {
@@ -17,6 +19,7 @@ class SourceFactory
 
         $this->id = new SourceId(Uuid::uuid4());
         $this->name = $faker->company();
+        $this->url = Url::createFromString($faker->url());
     }
 
     public static function setup(): self
@@ -31,11 +34,19 @@ class SourceFactory
         return $this;
     }
 
+    public function withUrl(string|Url $url): self
+    {
+        $this->url = $url instanceof Url ? $url : Url::createFromString($url);
+
+        return $this;
+    }
+
     public function create(): Source
     {
         return new Source(
             $this->id,
             $this->name,
+            $this->url,
         );
     }
 }

--- a/src-dev/Feed/Repository/InMemoryArticleRepository.php
+++ b/src-dev/Feed/Repository/InMemoryArticleRepository.php
@@ -6,7 +6,6 @@ use App\Feed\Domain\Article\Article;
 use App\Feed\Domain\Article\ArticleId;
 use App\Feed\Domain\Article\ArticleRepository;
 use App\Feed\Domain\Article\Exception\ArticleNotFoundException;
-use App\Feed\Domain\Article\Url\Url;
 
 final class InMemoryArticleRepository implements ArticleRepository
 {

--- a/src-dev/Fixture/SourceFixture.php
+++ b/src-dev/Fixture/SourceFixture.php
@@ -2,6 +2,7 @@
 
 namespace Dev\Fixture;
 
+use App\Common\Domain\Url\Url;
 use App\Feed\Domain\Source\Source;
 use App\Feed\Domain\Source\SourceId;
 use Doctrine\Bundle\FixturesBundle\Fixture;
@@ -15,12 +16,14 @@ final class SourceFixture extends Fixture
         $manager->persist(new Source(
             new SourceId('0c65cd65-bf4e-4bd1-ac1d-ccf707e19361'),
             'stitcher.io',
+            Url::createFromString('https://stitcher.io/rss'),
         ));
 
         // martinfowler.com
         $manager->persist(new Source(
             new SourceId('f2f38859-ba40-4252-90c5-a956056a1dae'),
             'martinfowler.com',
+            Url::createFromString('https://martinfowler.com/feed.atom'),
         ));
 
         $manager->flush();

--- a/src/Common/Domain/Url/Exception/MalformedUrlException.php
+++ b/src/Common/Domain/Url/Exception/MalformedUrlException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Feed\Domain\Article\Url\Exception;
+namespace App\Common\Domain\Url\Exception;
 
 use Exception;
 

--- a/src/Common/Domain/Url/Exception/SchemeNotSupportedException.php
+++ b/src/Common/Domain/Url/Exception/SchemeNotSupportedException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Feed\Domain\Article\Url\Exception;
+namespace App\Common\Domain\Url\Exception;
 
 use Exception;
 

--- a/src/Common/Domain/Url/Scheme.php
+++ b/src/Common/Domain/Url/Scheme.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Feed\Domain\Article\Url;
+namespace App\Common\Domain\Url;
 
 /**
  * List of supported schemes.

--- a/src/Common/Domain/Url/Url.php
+++ b/src/Common/Domain/Url/Url.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace App\Feed\Domain\Article\Url;
+namespace App\Common\Domain\Url;
 
-use App\Feed\Domain\Article\Url\Exception\MalformedUrlException;
-use App\Feed\Domain\Article\Url\Exception\SchemeNotSupportedException;
+use App\Common\Domain\Url\Exception\MalformedUrlException;
+use App\Common\Domain\Url\Exception\SchemeNotSupportedException;
 
 final readonly class Url
 {

--- a/src/Feed/Application/Command/Article/Handler/UpsertArticleHandler.php
+++ b/src/Feed/Application/Command/Article/Handler/UpsertArticleHandler.php
@@ -2,13 +2,13 @@
 
 namespace App\Feed\Application\Command\Article\Handler;
 
+use App\Common\Domain\Url\Exception\MalformedUrlException;
+use App\Common\Domain\Url\Url;
 use App\Common\Infrastructure\Messenger\CommandBus\AsCommandHandler;
 use App\Feed\Application\Command\Article\UpsertArticleCommand;
 use App\Feed\Domain\Article\Article;
 use App\Feed\Domain\Article\ArticleId;
 use App\Feed\Domain\Article\ArticleRepository;
-use App\Feed\Domain\Article\Url\Exception\MalformedUrlException;
-use App\Feed\Domain\Article\Url\Url;
 use App\Feed\Domain\Source\Exception\SourceNotFoundException;
 use App\Feed\Domain\Source\SourceRepository;
 use Ramsey\Uuid\Uuid;

--- a/src/Feed/Application/Service/FeedProvider/MartinFowlerFeedProvider.php
+++ b/src/Feed/Application/Service/FeedProvider/MartinFowlerFeedProvider.php
@@ -3,11 +3,13 @@
 namespace App\Feed\Application\Service\FeedProvider;
 
 use App\Feed\Application\FeedParser\FeedParser;
+use App\Feed\Domain\Source\SourceRepository;
 
 final readonly class MartinFowlerFeedProvider implements FeedProvider
 {
     public function __construct(
         private FeedParser $feedParser,
+        private SourceRepository $sourceRepository,
     ) {
     }
 
@@ -19,9 +21,11 @@ final readonly class MartinFowlerFeedProvider implements FeedProvider
 
     public function fetchFeedItems(): array
     {
+        $source = $this->sourceRepository->findByNameOrThrow($this::getSource());
+
         $newsItems = [];
 
-        foreach ($this->feedParser->fetchFeed($this::getSource(), 'https://martinfowler.com/feed.atom') as $item) {
+        foreach ($this->feedParser->fetchFeed($source->getName(), $source->getUrl()) as $item) {
             $newsItems[] = new FeedItem(
                 $item->title,
                 $this->deriveFirstParagraphFromHtmlText($item->summary),

--- a/src/Feed/Application/Service/FeedProvider/PhpWatchChangesFeedProvider.php
+++ b/src/Feed/Application/Service/FeedProvider/PhpWatchChangesFeedProvider.php
@@ -3,11 +3,13 @@
 namespace App\Feed\Application\Service\FeedProvider;
 
 use App\Feed\Application\FeedParser\FeedParser;
+use App\Feed\Domain\Source\SourceRepository;
 
 final class PhpWatchChangesFeedProvider implements FeedProvider
 {
     public function __construct(
         private FeedParser $feedParser,
+        private SourceRepository $sourceRepository,
     ) {
     }
 
@@ -19,6 +21,8 @@ final class PhpWatchChangesFeedProvider implements FeedProvider
 
     public function fetchFeedItems(): array
     {
-        return $this->feedParser->fetchFeed($this::getSource(), 'https://php.watch/feed/php-changes.xml');
+        $source = $this->sourceRepository->findByNameOrThrow($this::getSource());
+
+        return $this->feedParser->fetchFeed($source->getName(), $source->getUrl());
     }
 }

--- a/src/Feed/Application/Service/FeedProvider/PhpWatchNewsFeedProvider.php
+++ b/src/Feed/Application/Service/FeedProvider/PhpWatchNewsFeedProvider.php
@@ -3,11 +3,13 @@
 namespace App\Feed\Application\Service\FeedProvider;
 
 use App\Feed\Application\FeedParser\FeedParser;
+use App\Feed\Domain\Source\SourceRepository;
 
 final class PhpWatchNewsFeedProvider implements FeedProvider
 {
     public function __construct(
         private FeedParser $feedParser,
+        private SourceRepository $sourceRepository,
     ) {
     }
 
@@ -19,6 +21,8 @@ final class PhpWatchNewsFeedProvider implements FeedProvider
 
     public function fetchFeedItems(): array
     {
-        return $this->feedParser->fetchFeed(self::getSource(), 'https://php.watch/feed/news.xml');
+        $source = $this->sourceRepository->findByNameOrThrow($this::getSource());
+
+        return $this->feedParser->fetchFeed($source->getName(), $source->getUrl());
     }
 }

--- a/src/Feed/Application/Service/FeedProvider/StitcherFeedProvider.php
+++ b/src/Feed/Application/Service/FeedProvider/StitcherFeedProvider.php
@@ -3,11 +3,13 @@
 namespace App\Feed\Application\Service\FeedProvider;
 
 use App\Feed\Application\FeedParser\FeedParser;
+use App\Feed\Domain\Source\SourceRepository;
 
 final readonly class StitcherFeedProvider implements FeedProvider
 {
     public function __construct(
         private FeedParser $feedParser,
+        private SourceRepository $sourceRepository,
     ) {
     }
 
@@ -21,9 +23,11 @@ final readonly class StitcherFeedProvider implements FeedProvider
      */
     public function fetchFeedItems(): array
     {
+        $source = $this->sourceRepository->findByNameOrThrow($this::getSource());
+
         $feedItems = [];
 
-        foreach ($this->feedParser->fetchFeed(self::getSource(), 'https://stitcher.io/rss') as $item) {
+        foreach ($this->feedParser->fetchFeed($source->getName(), $source->getUrl()) as $item) {
             $feedItems[] = new FeedItem(
                 trim(html_entity_decode($item->title)), // Simple pie double encodes html, let's fix this later
                 $this->deriveFirstParagraphFromHtmlText($item->summary),

--- a/src/Feed/Application/Service/FeedProvider/SymfonyFeedProvider.php
+++ b/src/Feed/Application/Service/FeedProvider/SymfonyFeedProvider.php
@@ -3,11 +3,13 @@
 namespace App\Feed\Application\Service\FeedProvider;
 
 use App\Feed\Application\FeedParser\FeedParser;
+use App\Feed\Domain\Source\SourceRepository;
 
 final class SymfonyFeedProvider implements FeedProvider
 {
     public function __construct(
         private FeedParser $feedParser,
+        private SourceRepository $sourceRepository,
     ) {
     }
 
@@ -18,6 +20,8 @@ final class SymfonyFeedProvider implements FeedProvider
 
     public function fetchFeedItems(): array
     {
-        return $this->feedParser->fetchFeed(self::getSource(), 'https://feeds.feedburner.com/symfony/blog');
+        $source = $this->sourceRepository->findByNameOrThrow($this::getSource());
+
+        return $this->feedParser->fetchFeed($source->getName(), $source->getUrl());
     }
 }

--- a/src/Feed/Domain/Article/Article.php
+++ b/src/Feed/Domain/Article/Article.php
@@ -4,9 +4,9 @@ namespace App\Feed\Domain\Article;
 
 use App\Common\Domain\EventPublishingAggregateRoot;
 use App\Common\Domain\EventPublishingAggregateRootTrait;
+use App\Common\Domain\Url\Url;
 use App\Feed\Domain\Article\Event\Article\ArticleAddedEvent;
 use App\Feed\Domain\Article\Event\Article\ArticleUpdatedEvent;
-use App\Feed\Domain\Article\Url\Url;
 use App\Feed\Domain\Source\Source;
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;

--- a/src/Feed/Domain/Article/ArticleRepository.php
+++ b/src/Feed/Domain/Article/ArticleRepository.php
@@ -3,7 +3,6 @@
 namespace App\Feed\Domain\Article;
 
 use App\Feed\Domain\Article\Exception\ArticleNotFoundException;
-use App\Feed\Domain\Article\Url\Url;
 
 interface ArticleRepository
 {

--- a/src/Feed/Domain/Source/Source.php
+++ b/src/Feed/Domain/Source/Source.php
@@ -2,7 +2,7 @@
 
 namespace App\Feed\Domain\Source;
 
-use App\Feed\Infrastructure\Persistence\Doctrine\Source\DoctrineSourceRepository;
+use App\Common\Domain\Url\Url;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -16,12 +16,17 @@ class Source
     #[ORM\Column]
     private string $name;
 
+    #[ORM\Column(type: 'string', length: 512)]
+    private string $feedUrl;
+
     public function __construct(
         SourceId $id,
         string $name,
+        Url $feedUrl,
     ) {
         $this->id = (string) $id;
         $this->name = $name;
+        $this->feedUrl = (string) $feedUrl;
     }
 
     public function getId(): SourceId
@@ -35,5 +40,10 @@ class Source
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function getUrl(): Url
+    {
+        return Url::createFromString($this->feedUrl);
     }
 }

--- a/tests/Unit/Feed/Application/Command/Article/Handler/UpsertArticleHandlerTest.php
+++ b/tests/Unit/Feed/Application/Command/Article/Handler/UpsertArticleHandlerTest.php
@@ -2,11 +2,11 @@
 
 namespace Unit\Feed\Application\Command\Article\Handler;
 
+use App\Common\Domain\Url\Exception\MalformedUrlException;
+use App\Common\Domain\Url\Exception\SchemeNotSupportedException;
 use App\Feed\Application\Command\Article\Handler\UpsertArticleHandler;
 use App\Feed\Application\Command\Article\UpsertArticleCommand;
 use App\Feed\Domain\Article\ArticleId;
-use App\Feed\Domain\Article\Url\Exception\MalformedUrlException;
-use App\Feed\Domain\Article\Url\Exception\SchemeNotSupportedException;
 use App\Feed\Domain\Source\Exception\SourceNotFoundException;
 use DateTime;
 use Dev\Feed\Factory\ArticleFactory;

--- a/tests/Unit/Feed/Application/Service/FeedProvider/PhpWatchNewsFeedProviderTest.php
+++ b/tests/Unit/Feed/Application/Service/FeedProvider/PhpWatchNewsFeedProviderTest.php
@@ -5,6 +5,8 @@ namespace Unit\Feed\Application\Service\FeedProvider;
 use App\Feed\Application\Service\FeedProvider\PhpWatchNewsFeedProvider;
 use App\Feed\Infrastructure\FeedParser\RssParser\SimplePieFeedParser;
 use Dev\Common\Infrastructure\Logger\InMemoryLogger;
+use Dev\Feed\Factory\SourceFactory;
+use Dev\Feed\Repository\InMemorySourceRepository;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -13,6 +15,7 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 final class PhpWatchNewsFeedProviderTest extends TestCase
 {
     private InMemoryLogger $logger;
+    private InMemorySourceRepository $sourceRepository;
 
     private const EXTERNAL_FEED = <<<XML
 <?xml version="1.0" encoding="utf-8"?><feed xmlns="http://www.w3.org/2005/Atom">
@@ -57,6 +60,12 @@ XML;
     protected function setUp(): void
     {
         $this->logger = new InMemoryLogger();
+        $this->sourceRepository = new InMemorySourceRepository();
+
+        $this->sourceRepository->save(SourceFactory::setup()
+            ->withName(PhpWatchNewsFeedProvider::getSource())
+            ->withUrl('https://php.watch/feed/news.xml')
+            ->create());
 
         parent::setUp();
     }
@@ -71,7 +80,7 @@ XML;
             new MockResponse(self::EXTERNAL_FEED, ['response_headers' => ['Content-Type' => 'application/rss+xml']])
         ]);
 
-        $feedProvider = new PhpWatchNewsFeedProvider(new SimplePieFeedParser($client, $this->logger));
+        $feedProvider = new PhpWatchNewsFeedProvider(new SimplePieFeedParser($client, $this->logger), $this->sourceRepository);
 
         // Act
         $feedItems = $feedProvider->fetchFeedItems();
@@ -111,7 +120,7 @@ XML;
             new MockResponse(self::MALFORMED_EXTERNAL_FEED, ['response_headers' => ['Content-Type' => 'application/rss+xml']])
         ]);
 
-        $feedProvider = new PhpWatchNewsFeedProvider(new SimplePieFeedParser($client, $this->logger));
+        $feedProvider = new PhpWatchNewsFeedProvider(new SimplePieFeedParser($client, $this->logger), $this->sourceRepository);
 
         // Act
         $feedItems = $feedProvider->fetchFeedItems();

--- a/tests/Unit/Feed/Domain/Article/Url/UrlTest.php
+++ b/tests/Unit/Feed/Domain/Article/Url/UrlTest.php
@@ -2,10 +2,10 @@
 
 namespace Unit\Feed\Domain\Article\Url;
 
-use App\Feed\Domain\Article\Url\Exception\MalformedUrlException;
-use App\Feed\Domain\Article\Url\Exception\SchemeNotSupportedException;
-use App\Feed\Domain\Article\Url\Scheme;
-use App\Feed\Domain\Article\Url\Url;
+use App\Common\Domain\Url\Exception\MalformedUrlException;
+use App\Common\Domain\Url\Exception\SchemeNotSupportedException;
+use App\Common\Domain\Url\Scheme;
+use App\Common\Domain\Url\Url;
 use PHPUnit\Framework\TestCase;
 
 final class UrlTest extends TestCase


### PR DESCRIPTION
The feed url of the source is stored in the feedprovider. We want to get rid of the feedprovider to have a no-code way to add new sources.

In this PR we extract the feed urls from the providers and add them to the source entity instead.