### PR TITLE
Introduce feeditem normalizers

### DIFF
--- a/src/Feed/Application/Service/FeedItemNormalizer/FeedItemNormalizer.php
+++ b/src/Feed/Application/Service/FeedItemNormalizer/FeedItemNormalizer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Feed\Application\Service\FeedItemNormalizer;
+
+use App\Feed\Application\Service\FeedProvider\FeedItem;
+
+interface FeedItemNormalizer
+{
+    public function __invoke(FeedItem $feedItem): FeedItem;
+}

--- a/src/Feed/Application/Service/FeedItemNormalizer/RemoveHtmlTagsNormalizer.php
+++ b/src/Feed/Application/Service/FeedItemNormalizer/RemoveHtmlTagsNormalizer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Feed\Application\Service\FeedItemNormalizer;
+
+use App\Feed\Application\Service\FeedProvider\FeedItem;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
+
+#[AsTaggedItem(priority: 20)]
+final class RemoveHtmlTagsNormalizer implements FeedItemNormalizer
+{
+    public function __invoke(FeedItem $feedItem): FeedItem
+    {
+        return new FeedItem(
+            trim(html_entity_decode(strip_tags($feedItem->title))),
+            trim(html_entity_decode(strip_tags($feedItem->summary))),
+            $feedItem->url,
+            $feedItem->updated,
+            $feedItem->source,
+        );
+    }
+}

--- a/src/Feed/Application/Service/FeedItemNormalizer/ShortenSummaryNormalizer.php
+++ b/src/Feed/Application/Service/FeedItemNormalizer/ShortenSummaryNormalizer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Feed\Application\Service\FeedItemNormalizer;
+
+use App\Feed\Application\Service\FeedProvider\FeedItem;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
+
+#[AsTaggedItem(priority: -10)]
+final class ShortenSummaryNormalizer implements FeedItemNormalizer
+{
+    private const SUMMARY_LENGTH = 280;
+
+    public function __invoke(FeedItem $feedItem): FeedItem
+    {
+        if (strlen($feedItem->summary) <= self::SUMMARY_LENGTH) {
+            return $feedItem;
+        }
+        return new FeedItem(
+            $feedItem->title,
+            mb_strimwidth($feedItem->summary, 0, self::SUMMARY_LENGTH, "..."),
+            $feedItem->url,
+            $feedItem->updated,
+            $feedItem->source,
+        );
+    }
+}

--- a/src/Feed/Application/Service/FeedProvider/StitcherFeedProvider.php
+++ b/src/Feed/Application/Service/FeedProvider/StitcherFeedProvider.php
@@ -3,12 +3,19 @@
 namespace App\Feed\Application\Service\FeedProvider;
 
 use App\Feed\Application\FeedParser\FeedParser;
+use App\Feed\Application\Service\FeedItemNormalizer\FeedItemNormalizer;
 use App\Feed\Domain\Source\SourceRepository;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 final readonly class StitcherFeedProvider implements FeedProvider
 {
     public function __construct(
         private FeedParser $feedParser,
+        /**
+         * @var iterable<FeedItemNormalizer>
+         */
+        #[AutowireIterator(FeedItemNormalizer::class)]
+        private iterable $feedItemNormalizers,
         private SourceRepository $sourceRepository,
     ) {
     }
@@ -27,35 +34,14 @@ final readonly class StitcherFeedProvider implements FeedProvider
 
         $feedItems = [];
 
-        foreach ($this->feedParser->fetchFeed($source->getName(), $source->getUrl()) as $item) {
-            $feedItems[] = new FeedItem(
-                trim(html_entity_decode($item->title)), // Simple pie double encodes html, let's fix this later
-                $this->deriveFirstParagraphFromHtmlText($item->summary),
-                $item->url,
-                $item->updated,
-                $item->source,
-            );
+        foreach ($this->feedParser->fetchFeed($source->getName(), $source->getUrl()) as $feedItem) {
+            foreach ($this->feedItemNormalizers as $feedItemNormalizer) {
+                $feedItem = $feedItemNormalizer($feedItem);
+            }
+
+            $feedItems[] = $feedItem;
         }
 
         return $feedItems;
-    }
-
-    private function deriveFirstParagraphFromHtmlText(string $text): string
-    {
-        $textFirstParagraphStart = strpos($text, '<p>');
-
-        if ($textFirstParagraphStart === false) {
-            return html_entity_decode(strip_tags(mb_strimwidth($text, 0, 277, "...")));
-        }
-
-        $textFirstParagraphEnd = strpos($text, '</p>', $textFirstParagraphStart);
-
-        $firstParagraph =  substr(
-            $text,
-            $textFirstParagraphStart,
-            $textFirstParagraphEnd - $textFirstParagraphStart + 4
-        );
-
-        return html_entity_decode(strip_tags($firstParagraph));
     }
 }

--- a/tests/Feed/Application/Service/FeedItemNormalizer/RemoveHtmlTagsNormalizerTest.php
+++ b/tests/Feed/Application/Service/FeedItemNormalizer/RemoveHtmlTagsNormalizerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Feed\Application\Service\FeedItemNormalizer;
+
+use App\Feed\Application\Service\FeedItemNormalizer\RemoveHtmlTagsNormalizer;
+use App\Feed\Application\Service\FeedProvider\FeedItem;
+use PHPUnit\Framework\TestCase;
+
+class RemoveHtmlTagsNormalizerTest extends TestCase
+{
+    private RemoveHtmlTagsNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new RemoveHtmlTagsNormalizer();
+
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_do_nothing_if_the_feed_item_does_not_contain_html(): void
+    {
+        // Arrange
+        $feedItem = new FeedItem(
+            'some title',
+            'some summary',
+            "https://example.com/feed",
+            new \DateTime('now'),
+            'some source',
+        );
+
+        // Act
+        $normalizedFeedItem = $this->normalizer->__invoke($feedItem);
+
+        // Assert
+        self::assertEquals($feedItem, $normalizedFeedItem);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_remove_html_tags_from_the_title_and_summary(): void
+    {
+        // Arrange
+        $feedItem = new FeedItem(
+            '<h1>A title with html</h1>',
+            '<p>Some summary</p><li><ul>-containing html</ul></li>',
+            "https://example.com/feed",
+            new \DateTime('now'),
+            'some source',
+        );
+
+        // Act
+        $normalizedFeedItem = $this->normalizer->__invoke($feedItem);
+
+        // Assert
+        self::assertSame("A title with html", $normalizedFeedItem->title);
+        self::assertSame("Some summary-containing html", $normalizedFeedItem->summary);
+    }
+}

--- a/tests/Feed/Application/Service/FeedItemNormalizer/ShortenSummaryNormalizerTest.php
+++ b/tests/Feed/Application/Service/FeedItemNormalizer/ShortenSummaryNormalizerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Feed\Application\Service\FeedItemNormalizer;
+
+use App\Feed\Application\Service\FeedItemNormalizer\ShortenSummaryNormalizer;
+use App\Feed\Application\Service\FeedProvider\FeedItem;
+use PHPUnit\Framework\TestCase;
+
+final class ShortenSummaryNormalizerTest extends TestCase
+{
+    private ShortenSummaryNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new ShortenSummaryNormalizer();
+
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_do_nothing_if_the_summary_is_short_enough(): void
+    {
+        // Arrange
+        $feedItem = new FeedItem(
+            'some title',
+            'a short summary',
+            "https://example.com/feed",
+            new \DateTime('now'),
+            'some source',
+        );
+
+        // Act
+        $normalizedFeedItem = $this->normalizer->__invoke($feedItem);
+
+        // Assert
+        self::assertEquals($feedItem, $normalizedFeedItem);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_shorten_a_long_summary(): void
+    {
+        // Arrange
+        $feedItem = new FeedItem(
+            'some title',
+            'Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32. The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.',
+            "https://example.com/feed",
+            new \DateTime('now'),
+            'some source',
+        );
+
+        // Act
+        $normalizedFeedItem = $this->normalizer->__invoke($feedItem);
+
+        // Assert
+        self::assertEquals(
+            'Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure La...',
+            $normalizedFeedItem->summary
+        );
+    }
+}

--- a/tests/Unit/Feed/Application/Service/FeedProvider/MartinFowlerFeedProviderTest.php
+++ b/tests/Unit/Feed/Application/Service/FeedProvider/MartinFowlerFeedProviderTest.php
@@ -2,6 +2,9 @@
 
 namespace Unit\Feed\Application\Service\FeedProvider;
 
+use App\Feed\Application\Service\FeedItemNormalizer\FeedItemNormalizer;
+use App\Feed\Application\Service\FeedItemNormalizer\RemoveHtmlTagsNormalizer;
+use App\Feed\Application\Service\FeedItemNormalizer\ShortenSummaryNormalizer;
 use App\Feed\Application\Service\FeedProvider\MartinFowlerFeedProvider;
 use App\Feed\Infrastructure\FeedParser\RssParser\SimplePieFeedParser;
 use DateTime;
@@ -17,6 +20,11 @@ class MartinFowlerFeedProviderTest extends TestCase
 {
     private InMemoryLogger $logger;
     private InMemorySourceRepository $sourceRepository;
+
+    /**
+     * @var iterable<FeedItemNormalizer>
+     */
+    private iterable $feedItemNormalizers;
 
     private const EXTERNAL_FEED = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -38,13 +46,7 @@ class MartinFowlerFeedProviderTest extends TestCase
     <updated>2023-07-27T10:34:00-04:00</updated>
     <id>tag:martinfowler.com,2023-07-27:Exploring-Gen-AI---Three-versions-of-a-median</id>
     <content type="html">
-&lt;p&gt;&lt;b class = 'author'&gt;Birgitta B&amp;#xF6;ckeler&lt;/b&gt; continues her explorations in using
-     LLMs, this time by asking GitHub Copilot to &lt;a href = 'https://martinfowler.com/articles/exploring-gen-ai.html#median---a-tale-in-three-functions'&gt;write a median
-     function&lt;/a&gt;. It gave her three suggestions to choose from. The
-     experience shows you still have to know what you're doing when asking LLMs
-     to write code, since the LLM's programming skills are often rather flawed.&lt;/p&gt;
-
-&lt;p&gt;&lt;a class = 'more' href = 'https://martinfowler.com/articles/exploring-gen-ai.html#median---a-tale-in-three-functions'&gt;moreâ€¦&lt;/a&gt;&lt;/p&gt;</content>
+&lt;p&gt;&lt;b class = 'author'&gt;Birgitta B&amp;#xF6;ckeler&lt;/b&gt; continues her explorations in using LLMs, this time by asking GitHub Copilot to &lt;a href = 'https://martinfowler.com/articles/exploring-gen-ai.html#median---a-tale-in-three-functions'&gt;write a median function&lt;/a&gt;. It gave her three suggestions to choose from. The experience shows you still have to know what you're doing when asking LLMs to write code, since the LLM's programming skills are often rather flawed.&lt;/p&gt;&lt;p&gt;&lt;a class = 'more' href = 'https://martinfowler.com/articles/exploring-gen-ai.html#median---a-tale-in-three-functions'&gt;moreâ€¦&lt;/a&gt;&lt;/p&gt;</content>
   </entry>
 
 <entry>
@@ -53,14 +55,7 @@ class MartinFowlerFeedProviderTest extends TestCase
     <updated>2023-07-26T10:52:00-04:00</updated>
     <id>tag:martinfowler.com,2023-07-26:Exploring-Gen-AI---The-toolchain</id>
     <content type="html">
-&lt;p&gt;My colleague &lt;b class = 'author'&gt;Birgitta B&amp;#xF6;ckeler&lt;/b&gt; has long been one of our senior
-     technology leaders in Germany. She's now moved into a new role coordinating
-     our work with Generative AI and its effect of software delivery practices.
-     She's decided to publish her exploration in a series of memos. The first
-     memo looks at the &lt;a href = 'https://martinfowler.com/articles/exploring-gen-ai.html#the-toolchain'&gt;current toolchain for LLMs&lt;/a&gt;, categorizing them by what
-     tasks they help with, how we interact with the LLM, and where they come from.&lt;/p&gt;
-
-&lt;p&gt;&lt;a class = 'more' href = 'https://martinfowler.com/articles/exploring-gen-ai.html#the-toolchain'&gt;moreâ€¦&lt;/a&gt;&lt;/p&gt;</content>
+&lt;p&gt;My colleague &lt;b class = 'author'&gt;Birgitta B&amp;#xF6;ckeler&lt;/b&gt; has long been one of our senior technology leaders in Germany. She's now moved into a new role coordinating our work with Generative AI and its effect of software delivery practices. She's decided to publish her exploration in a series of memos. The first memo looks at the &lt;a href = 'https://martinfowler.com/articles/exploring-gen-ai.html#the-toolchain'&gt;current toolchain for LLMs&lt;/a&gt;, categorizing them by what tasks they help with, how we interact with the LLM, and where they come from.&lt;/p&gt;&lt;p&gt;&lt;a class = 'more' href = 'https://martinfowler.com/articles/exploring-gen-ai.html#the-toolchain'&gt;moreâ€¦&lt;/a&gt;&lt;/p&gt;</content>
   </entry>
 
 <entry>
@@ -70,26 +65,7 @@ class MartinFowlerFeedProviderTest extends TestCase
     <id>https://martinfowler.com/bliki/TeamTopologies.html</id>
     <category term="bliki"/>
     <content type="html">
-&lt;div class="book-sidebar no-text"&gt;&lt;span class="img-link"&gt;&lt;a href="https://www.amazon.com/gp/product/1942788819/ref=as_li_tl?ie=UTF8&amp;amp;camp=1789&amp;amp;creative=9325&amp;amp;creativeASIN=1942788819&amp;amp;linkCode=as2&amp;amp;tag=martinfowlerc-20"&gt;&lt;img class="cover" src="https://martinfowler.com/bliki/images/team-topologies/book.jpg"&gt;&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;
-
-&lt;p&gt;Any large software effort, such as the software estate for a large
-    company, requires a lot of people - and whenever you have a lot of people
-    you have to figure out how to divide them into effective teams. Forming
-    &lt;a href="/bliki/BusinessCapabilityCentric.html"&gt;Business Capability Centric&lt;/a&gt; teams helps software efforts to
-    be responsive to customersâ€™ needs, but the range of skills required often
-    overwhelms such teams. &lt;a href="https://www.amazon.com/gp/product/1942788819/ref=as_li_tl?ie=UTF8&amp;amp;camp=1789&amp;amp;creative=9325&amp;amp;creativeASIN=1942788819&amp;amp;linkCode=as2&amp;amp;tag=martinfowlerc-20"&gt;Team Topologies&lt;/a&gt; is a model
-    for describing the organization of software development teams,
-    developed by Matthew Skelton and Manuel Pais. It defines four forms
-    of teams and three modes of team
-    interactions. The model encourages healthy interactions that allow 
-    business-capability centric teams to flourish in their task of providing a
-    steady flow of valuable software.&lt;/p&gt;
-
-&lt;p&gt;The primary kind of team in this framework is the &lt;b&gt;stream-aligned
-    team&lt;/b&gt;, a &lt;a href="/bliki/BusinessCapabilityCentric.html"&gt;Business Capability Centric&lt;/a&gt; team that is
-    responsible for software for a single business capability. These are
-    long-running teams, thinking of their efforts as providing a &lt;a href="/articles/products-over-projects.html"&gt;software
-    product&lt;/a&gt; to enhance the business capability.&lt;/p&gt;
+&lt;div class="book-sidebar no-text"&gt;&lt;span class="img-link"&gt;&lt;a href="https://www.amazon.com/gp/product/1942788819/ref=as_li_tl?ie=UTF8&amp;amp;camp=1789&amp;amp;creative=9325&amp;amp;creativeASIN=1942788819&amp;amp;linkCode=as2&amp;amp;tag=martinfowlerc-20"&gt;&lt;img class="cover" src="https://martinfowler.com/bliki/images/team-topologies/book.jpg"&gt;&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;&lt;p&gt;Any large software effort, such as the software estate for a large company, requires a lot of people - and whenever you have a lot of people you have to figure out how to divide them into effective teams. Forming &lt;a href="/bliki/BusinessCapabilityCentric.html"&gt;Business Capability Centric&lt;/a&gt; teams helps software efforts to be responsive to customersâ€™ needs, but the range of skills required often overwhelms such teams. &lt;a href="https://www.amazon.com/gp/product/1942788819/ref=as_li_tl?ie=UTF8&amp;amp;camp=1789&amp;amp;creative=9325&amp;amp;creativeASIN=1942788819&amp;amp;linkCode=as2&amp;amp;tag=martinfowlerc-20"&gt;Team Topologies&lt;/a&gt; is a model for describing the organization of software development teams, developed by Matthew Skelton and Manuel Pais. It defines four forms of teams and three modes of team interactions. The model encourages healthy interactions that allow  business-capability centric teams to flourish in their task of providing a steady flow of valuable software.&lt;/p&gt;&lt;p&gt;The primary kind of team in this framework is the &lt;b&gt;stream-aligned team&lt;/b&gt;, a &lt;a href="/bliki/BusinessCapabilityCentric.html"&gt;Business Capability Centric&lt;/a&gt; team that is responsible for software for a single business capability. These are long-running teams, thinking of their efforts as providing a &lt;a href="/articles/products-over-projects.html"&gt;software product&lt;/a&gt; to enhance the business capability.&lt;/p&gt;
 </content>
   </entry>
 </feed>
@@ -114,13 +90,7 @@ XML;
     <link href="https://martinfowler.com/articles/exploring-gen-ai.html#median---a-tale-in-three-functions"/>
     <id>tag:martinfowler.com,2023-07-27:Exploring-Gen-AI---Three-versions-of-a-median</id>
     <content type="html">
-&lt;p&gt;&lt;b class = 'author'&gt;Birgitta B&amp;#xF6;ckeler&lt;/b&gt; continues her explorations in using
-     LLMs, this time by asking GitHub Copilot to &lt;a href = 'https://martinfowler.com/articles/exploring-gen-ai.html#median---a-tale-in-three-functions'&gt;write a median
-     function&lt;/a&gt;. It gave her three suggestions to choose from. The
-     experience shows you still have to know what you're doing when asking LLMs
-     to write code, since the LLM's programming skills are often rather flawed.&lt;/p&gt;
-
-&lt;p&gt;&lt;a class = 'more' href = 'https://martinfowler.com/articles/exploring-gen-ai.html#median---a-tale-in-three-functions'&gt;moreâ€¦&lt;/a&gt;&lt;/p&gt;</content>
+&lt;p&gt;&lt;b class = 'author'&gt;Birgitta B&amp;#xF6;ckeler&lt;/b&gt; continues her explorations in using LLMs, this time by asking GitHub Copilot to &lt;a href = 'https://martinfowler.com/articles/exploring-gen-ai.html#median---a-tale-in-three-functions'&gt;write a median function&lt;/a&gt;. It gave her three suggestions to choose from. The experience shows you still have to know what you're doing when asking LLMs to write code, since the LLM's programming skills are often rather flawed.&lt;/p&gt; &lt;p&gt;&lt;a class = 'more' href = 'https://martinfowler.com/articles/exploring-gen-ai.html#median---a-tale-in-three-functions'&gt;moreâ€¦&lt;/a&gt;&lt;/p&gt;</content>
   </entry>
 </feed>
 XML;
@@ -135,6 +105,11 @@ XML;
             ->withUrl('https://martinfowler.com/feed.atom')
             ->create());
 
+        $this->feedItemNormalizers = [
+            new RemoveHtmlTagsNormalizer(),
+            new ShortenSummaryNormalizer(),
+        ];
+
         parent::setUp();
     }
 
@@ -148,7 +123,7 @@ XML;
             new MockResponse(self::EXTERNAL_FEED, ['response_headers' => ['Content-Type' => 'application/rss+xml']])
         ]);
 
-        $feedProvider = new MartinFowlerFeedProvider(new SimplePieFeedParser($client, $this->logger), $this->sourceRepository);
+        $feedProvider = new MartinFowlerFeedProvider(new SimplePieFeedParser($client, $this->logger), $this->feedItemNormalizers, $this->sourceRepository);
 
         // Act
         $feedItems = $feedProvider->fetchFeedItems();
@@ -158,7 +133,7 @@ XML;
 
         self::assertSame("Exploring Gen AI - Three versions of a median", $feedItems[0]->title);
         self::assertSame(
-            "Birgitta Böckeler continues her explorations in using LLMs, this time by asking GitHub Copilot to write a median function. It gave her three suggestions to choose from. The experience shows you still have to know what you're doing when asking LLMs to write code, since the LLM's programming skills are often rather flawed.",
+            "Birgitta Böckeler continues her explorations in using LLMs, this time by asking GitHub Copilot to write a median function. It gave her three suggestions to choose from. The experience shows you still have to know what you're doing when asking LLMs to write code, since the LLM'...",
             $feedItems[0]->summary
         );
         self::assertSame("https://martinfowler.com/articles/exploring-gen-ai.html#median---a-tale-in-three-functions", $feedItems[0]->url);
@@ -167,7 +142,7 @@ XML;
 
         self::assertSame("Exploring Gen AI - The toolchain", $feedItems[1]->title);
         self::assertSame(
-            "My colleague Birgitta Böckeler has long been one of our senior technology leaders in Germany. She's now moved into a new role coordinating our work with Generative AI and its effect of software delivery practices. She's decided to publish her exploration in a series of memos. The first memo looks at the current toolchain for LLMs, categorizing them by what tasks they help with, how we interact with the LLM, and where they come from.",
+            "My colleague Birgitta Böckeler has long been one of our senior technology leaders in Germany. She's now moved into a new role coordinating our work with Generative AI and its effect of software delivery practices. She's decided to publish her exploration in a series of memos. ...",
             $feedItems[1]->summary
         );
         self::assertSame("https://martinfowler.com/articles/exploring-gen-ai.html#the-toolchain", $feedItems[1]->url);
@@ -176,7 +151,7 @@ XML;
 
         self::assertSame("Bliki: TeamTopologies", $feedItems[2]->title);
         self::assertSame(
-            "Any large software effort, such as the software estate for a large company, requires a lot of people - and whenever you have a lot of people you have to figure out how to divide them into effective teams. Forming Business Capability Centric teams helps software efforts to be responsive to customersâ€™ needs, but the range of skills required often overwhelms such teams. Team Topologies is a model for describing the organization of software development teams, developed by Matthew Skelton and Manuel Pais. It defines four forms of teams and three modes of team interactions. The model encourages healthy interactions that allow business-capability centric teams to flourish in their task of providing a steady flow of valuable software.",
+            "Any large software effort, such as the software estate for a large company, requires a lot of people - and whenever you have a lot of people you have to figure out how to divide them into effective teams. Forming Business Capability Centric teams helps software efforts to be r...",
             $feedItems[2]->summary
         );
         self::assertSame("https://martinfowler.com/bliki/TeamTopologies.html", $feedItems[2]->url);
@@ -203,7 +178,7 @@ XML;
             new MockResponse(self::MALFORMED_EXTERNAL_FEED, ['response_headers' => ['Content-Type' => 'application/rss+xml']])
         ]);
 
-        $feedProvider = new MartinFowlerFeedProvider(new SimplePieFeedParser($client, $this->logger), $this->sourceRepository);
+        $feedProvider = new MartinFowlerFeedProvider(new SimplePieFeedParser($client, $this->logger), $this->feedItemNormalizers, $this->sourceRepository);
 
         // Act
         $feedItems = $feedProvider->fetchFeedItems();


### PR DESCRIPTION
These normalizers can be used to straighten out the outputs from all the different feed sources.

We are used to doing this in the feedprovider itself, but since we want to remove these we need a general soltuion.

In this PR we introduce two normalizers, one that removes html tags and another one that shortens the summary.