### PR TITLE
Fix & verify migrations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,32 @@ jobs:
           php_version: ${{ env.PHP_VERSION }}
           configuration: "phpstan.neon"
 
+  verify_migrations:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_DB: app
+          POSTGRES_PASSWORD: development
+          POSTGRES_USER: development
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+          extensions: pdo_pgsql
+      - run: composer install
+      - run: php bin/console doctrine:migrations:migrate
+      - run: php bin/console doctrine:schema:validate
+
   unit_tests:
     runs-on: ubuntu-latest
     steps:

--- a/migrations/Version20250124212701.php
+++ b/migrations/Version20250124212701.php
@@ -25,7 +25,7 @@ final class Version20250124212701 extends AbstractMigration
         // Create default category
         $this->addSql("INSERT INTO categories (id, name) VALUES ('fc4b87d7-9b19-4770-b312-3ccb1da69e54', 'default')");
 
-        $this->addSql("ALTER TABLE sources ADD default_category_id VARCHAR DEFAULT 'fc4b87d7-9b19-4770-b312-3ccb1da69e54'");
+        $this->addSql("ALTER TABLE sources ADD category_id VARCHAR DEFAULT 'fc4b87d7-9b19-4770-b312-3ccb1da69e54'");
         $this->addSql('ALTER TABLE sources ADD CONSTRAINT FK_D25D65F2C6B58E54 FOREIGN KEY (category_id) REFERENCES categories (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->addSql('CREATE INDEX IDX_D25D65F2C6B58E54 ON sources (category_id)');
     }

--- a/migrations/Version20250403193800.php
+++ b/migrations/Version20250403193800.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250403193800 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE articles ALTER source_id TYPE VARCHAR');
+        $this->addSql('ALTER TABLE articles ADD CONSTRAINT FK_BFDD3168953C1C61 FOREIGN KEY (source_id) REFERENCES sources (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE sources ALTER feed_url TYPE VARCHAR(512)');
+        $this->addSql('ALTER TABLE sources ALTER feed_url DROP DEFAULT');
+        $this->addSql('ALTER TABLE sources ALTER category_id DROP DEFAULT');
+        $this->addSql('ALTER INDEX idx_d25d65f2c6b58e54 RENAME TO IDX_D25D65F212469DE2');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE articles DROP CONSTRAINT FK_BFDD3168953C1C61');
+        $this->addSql('ALTER TABLE articles ALTER source_id TYPE VARCHAR(255)');
+        $this->addSql('ALTER TABLE sources ALTER feed_url TYPE VARCHAR(512)');
+        $this->addSql('ALTER TABLE sources ALTER feed_url SET DEFAULT \'\'');
+        $this->addSql('ALTER TABLE sources ALTER category_id SET DEFAULT \'fc4b87d7-9b19-4770-b312-3ccb1da69e54\'');
+        $this->addSql('ALTER INDEX idx_d25d65f212469de2 RENAME TO idx_d25d65f2c6b58e54');
+    }
+}


### PR DESCRIPTION
The migrations broke, we only found out in prod because the migrations failed there.

In this PR we fix the migrations and also introduce a CI job that verifies if the migration can execute and that the migration is up to date with the scheme.